### PR TITLE
feat(upstream): reasoning_effort 自动降级 + OpenAI 规范化 SSE 帧

### DIFF
--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"workbuddy2api/internal/auth"
@@ -111,6 +112,10 @@ type apiEnvelope struct {
 type Client struct {
 	HTTP *http.Client
 
+	// effortsMu/efforts 缓存各模型 supportedEfforts（FetchModels 刷新），供请求体 effort 降级。
+	effortsMu sync.RWMutex
+	efforts   map[string][]string
+
 	// SanitizeFingerprints 出站请求体黑名单指纹脱敏开关（默认 true；false 完全还原）。
 	SanitizeFingerprints bool
 
@@ -146,7 +151,21 @@ func (c *Client) chatBase(a *auth.Auth) string {
 
 // prepareBody 组装出站请求体（脱敏开关由 Client.SanitizeFingerprints 控制）。
 func (c *Client) prepareBody(body []byte) []byte {
-	return PrepareBodyOpt(body, c.SanitizeFingerprints)
+	return PrepareBodyOptWithEfforts(body, c.SanitizeFingerprints, c.effortsSnapshot())
+}
+
+// effortsSnapshot 返回 effort 能力缓存副本；nil 表示未知（透传不降级）。
+func (c *Client) effortsSnapshot() map[string][]string {
+	c.effortsMu.RLock()
+	defer c.effortsMu.RUnlock()
+	if len(c.efforts) == 0 {
+		return nil
+	}
+	cp := make(map[string][]string, len(c.efforts))
+	for k, v := range c.efforts {
+		cp[k] = v
+	}
+	return cp
 }
 
 func (c *Client) billingBase(a *auth.Auth) string {
@@ -253,8 +272,9 @@ func (c *Client) ChatStream(a *auth.Auth, body []byte) (rc io.ReadCloser, status
 type ModelInfo struct {
 	ID            string
 	Name          string
-	ContextWindow int64 // = maxInputTokens
-	MaxTokens     int64 // = maxOutputTokens
+	ContextWindow int64    // = maxInputTokens
+	MaxTokens     int64    // = maxOutputTokens
+	Efforts       []string // reasoning.supportedEfforts（空=未知/固定档）
 }
 
 // FetchModels 调上游动态模型接口。
@@ -289,6 +309,10 @@ func (c *Client) FetchModels(a *auth.Auth) ([]ModelInfo, error) {
 				MaxInputTokens  int64  `json:"maxInputTokens"`
 				MaxOutputTokens int64  `json:"maxOutputTokens"`
 				Disabled        bool   `json:"disabled"`
+				Reasoning       struct {
+					Effort           string   `json:"effort"`
+					SupportedEfforts []string `json:"supportedEfforts"`
+				} `json:"reasoning"`
 			} `json:"models"`
 			Agents []struct {
 				Name   string   `json:"name"`
@@ -318,6 +342,7 @@ func (c *Client) FetchModels(a *auth.Auth) ([]ModelInfo, error) {
 		MaxInputTokens  int64
 		MaxOutputTokens int64
 		Disabled        bool
+		Efforts         []string
 	}, len(env.Data.Models))
 	for _, m := range env.Data.Models {
 		dynMap[m.ID] = struct {
@@ -326,7 +351,8 @@ func (c *Client) FetchModels(a *auth.Auth) ([]ModelInfo, error) {
 			MaxInputTokens  int64
 			MaxOutputTokens int64
 			Disabled        bool
-		}{m.ID, m.Name, m.MaxInputTokens, m.MaxOutputTokens, m.Disabled}
+			Efforts         []string
+		}{m.ID, m.Name, m.MaxInputTokens, m.MaxOutputTokens, m.Disabled, m.Reasoning.SupportedEfforts}
 	}
 	out := make([]ModelInfo, 0, len(cliIDs))
 	for _, id := range cliIDs {
@@ -339,11 +365,22 @@ func (c *Client) FetchModels(a *auth.Auth) ([]ModelInfo, error) {
 			Name:          m.Name,
 			ContextWindow: m.MaxInputTokens,
 			MaxTokens:     m.MaxOutputTokens,
+			Efforts:       m.Efforts,
 		})
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("models api returned empty list")
 	}
+	// 刷新 effort 能力缓存（供请求体降级）。
+	cache := make(map[string][]string, len(out))
+	for _, mi := range out {
+		if len(mi.Efforts) > 0 {
+			cache[mi.ID] = mi.Efforts
+		}
+	}
+	c.effortsMu.Lock()
+	c.efforts = cache
+	c.effortsMu.Unlock()
 	return out, nil
 }
 

--- a/internal/upstream/payload.go
+++ b/internal/upstream/payload.go
@@ -5,11 +5,19 @@ package upstream
 
 import (
 	"encoding/json"
+	"log"
 	"strings"
 )
 
 // PrepareBodyOpt 单 pass 改写；sanitize=false 时行为完全还原（仅强制 stream + 归一化 tool_choice）。
 func PrepareBodyOpt(src []byte, sanitize bool) []byte {
+	return PrepareBodyOptWithEfforts(src, sanitize, nil)
+}
+
+// PrepareBodyOptWithEfforts 在 PrepareBodyOpt 基础上按模型 supportedEfforts 降级 reasoning_effort：
+// 仅当请求显式携带且模型不支持该档位时，改为 ≤请求档位的最高支持档；支持档全部高于请求档时取最低档；
+// 未知模型/未知档位/未携带该字段一律透传。
+func PrepareBodyOptWithEfforts(src []byte, sanitize bool, efforts map[string][]string) []byte {
 	if len(src) == 0 {
 		return src
 	}
@@ -19,6 +27,7 @@ func PrepareBodyOpt(src []byte, sanitize bool) []byte {
 	}
 	obj["stream"] = true
 	normalizeToolChoice(obj)
+	normalizeReasoningEffort(obj, efforts)
 	if sanitize {
 		if msgs, ok := obj["messages"].([]any); ok {
 			sanitizeMessages(msgs)
@@ -29,6 +38,67 @@ func PrepareBodyOpt(src []byte, sanitize bool) []byte {
 		return src
 	}
 	return out
+}
+
+// effortRank 档位从低到高。
+var effortRank = map[string]int{"off": 0, "minimal": 1, "low": 2, "medium": 3, "high": 4, "xhigh": 5, "max": 6}
+
+// normalizeReasoningEffort 按模型 supportedEfforts 降级 reasoning_effort（snake/camel 双字段兼容）。
+func normalizeReasoningEffort(obj map[string]any, efforts map[string][]string) {
+	if len(efforts) == 0 {
+		return
+	}
+	model, _ := obj["model"].(string)
+	if model == "" {
+		return
+	}
+	supported, ok := efforts[model]
+	if !ok || len(supported) == 0 {
+		return
+	}
+	key := ""
+	if _, present := obj["reasoning_effort"]; present {
+		key = "reasoning_effort"
+	} else if _, present := obj["reasoningEffort"]; present {
+		key = "reasoningEffort"
+	} else {
+		return
+	}
+	reqStr, ok := obj[key].(string)
+	if !ok {
+		return
+	}
+	reqStr = strings.TrimSpace(strings.ToLower(reqStr))
+	reqIdx, known := effortRank[reqStr]
+	if !known {
+		return
+	}
+	best, bestIdx := "", -1
+	for _, s := range supported {
+		idx, k := effortRank[strings.TrimSpace(strings.ToLower(s))]
+		if k && idx <= reqIdx && idx > bestIdx {
+			best, bestIdx = s, idx
+		}
+	}
+	if best != "" {
+		if !strings.EqualFold(best, reqStr) {
+			obj[key] = best
+			log.Printf("reasoning_effort downgraded model=%s %s -> %s", model, reqStr, best)
+		}
+		return
+	}
+	// 支持档全部高于请求档：取最低支持档（偏离最小）。
+	lowest, lowestIdx := "", 1<<30
+	for _, s := range supported {
+		idx, k := effortRank[strings.TrimSpace(strings.ToLower(s))]
+		if k && idx < lowestIdx {
+			lowest, lowestIdx = s, idx
+		}
+	}
+	if lowest != "" {
+		obj[key] = lowest
+		log.Printf("reasoning_effort floored model=%s %s -> %s", model, reqStr, lowest)
+	}
 }
 
 // normalizeToolChoice 按上游 Go struct（string 类型）改写 OpenAI tool_choice。

--- a/internal/upstream/sse.go
+++ b/internal/upstream/sse.go
@@ -189,7 +189,12 @@ func sortInts(a []int) {
 	}
 }
 
-// Stream 透传上游 SSE 到 w（每行 flush），保证至少写一个 [DONE]。
+// 流式策略：逐帧透传（规范化后空 content 噪声已除，TUI 单 part 连续渲染，
+// 恢复与上游一致的平滑流式）。如 TUI 思考区再现一词一行，将下方 mustFlush
+// 策略改回按阈值合并即可（git 历史 sse.go.bak4-* 有完整实现）。
+
+// Stream 透传上游 SSE 到 w：可合并的 delta 帧按阈值批量合并后下发，其余帧
+// （finish/usage/tool_calls/[DONE] 等）先冲刷待批再原样透传，保证至少写一个 [DONE]。
 // 调用方必须先设置过 status 200；本函数自设 SSE headers。
 func Stream(w http.ResponseWriter, r io.Reader) error {
 	h := w.Header()
@@ -198,13 +203,252 @@ func Stream(w http.ResponseWriter, r io.Reader) error {
 	h.Set("Connection", "keep-alive")
 	h.Set("X-Accel-Buffering", "no")
 	fl, _ := w.(http.Flusher)
+
+	var (
+		base       map[string]any // 批次首帧模板（保留 id/model/created/role 等元数据）
+		hasC, hasR bool
+		sbC, sbR   strings.Builder
+		sawDone    bool
+	)
+
+	// normalizeFrame 以 OpenAI 流式规范白名单重建帧：仅保留标准字段，
+	// 剔除上游噪声（finish_reason:"" → null、空 content/refusal、空 tool_calls 列表、
+	// null function_call/extra_fields、顶层未知字段），空 delta 键一律省略，
+	// 保证任意标准客户端按规范解析。
+	normalizeFrame := func(obj map[string]any) map[string]any {
+		out := map[string]any{}
+		for _, k := range []string{"id", "object", "created", "model", "system_fingerprint", "service_tier"} {
+			if v, ok := obj[k]; ok && v != nil {
+				out[k] = v
+			}
+		}
+		if _, ok := out["object"]; !ok {
+			out["object"] = "chat.completion.chunk"
+		}
+		if _, ok := out["id"]; !ok {
+			out["id"] = "chatcmpl-wb2api"
+		}
+		if chs, ok := obj["choices"].([]any); ok {
+			nchs := make([]any, 0, len(chs))
+			for _, ci := range chs {
+				c, ok := ci.(map[string]any)
+				if !ok {
+					continue
+				}
+				nc := map[string]any{}
+				if idx, ok := c["index"]; ok {
+					nc["index"] = idx
+				}
+				delta := map[string]any{}
+				if d, ok := c["delta"].(map[string]any); ok {
+					if v, ok := d["role"].(string); ok && v != "" {
+						delta["role"] = v
+					}
+					if v, ok := d["content"].(string); ok && v != "" {
+						delta["content"] = v
+					}
+					if v, ok := d["reasoning_content"].(string); ok && v != "" {
+						delta["reasoning_content"] = v
+					}
+					if v, ok := d["refusal"].(string); ok && v != "" {
+						delta["refusal"] = v
+					}
+					if tcs, ok := d["tool_calls"].([]any); ok && len(tcs) > 0 {
+						delta["tool_calls"] = tcs
+					}
+					if fc, ok := d["function_call"]; ok && fc != nil {
+						// 空占位 function_call（name/arguments 全空）视为噪声剔除
+						keep := false
+						if fcm, ok2 := fc.(map[string]any); ok2 {
+							n, _ := fcm["name"].(string)
+							a, _ := fcm["arguments"].(string)
+							keep = n != "" || a != ""
+						} else {
+							keep = true
+						}
+						if keep {
+							delta["function_call"] = fc
+						}
+					}
+				}
+				nc["delta"] = delta
+				if fr, ok := c["finish_reason"].(string); ok && fr != "" {
+					nc["finish_reason"] = fr
+				} else {
+					nc["finish_reason"] = nil
+				}
+				nchs = append(nchs, nc)
+			}
+			out["choices"] = nchs
+		}
+		if u, ok := obj["usage"]; ok {
+			out["usage"] = u
+		} else {
+			out["usage"] = nil
+		}
+		return out
+	}
+
+	flush := func() error {
+		if base == nil {
+			return nil
+		}
+		if chs, ok := base["choices"].([]any); ok && len(chs) > 0 {
+			if ch0, ok := chs[0].(map[string]any); ok {
+				delta, _ := ch0["delta"].(map[string]any)
+				if delta == nil {
+					delta = map[string]any{}
+					ch0["delta"] = delta
+				}
+				// 空串字段直接删 key：纯 reasoning 帧不带 content:""，避免客户端
+				// 每帧因空 content 建多余 text part/边界（表现为频繁换行）。
+				if hasC {
+					if s := sbC.String(); s != "" {
+						delta["content"] = s
+					} else {
+						delete(delta, "content")
+					}
+				}
+				if hasR {
+					if s := sbR.String(); s != "" {
+						delta["reasoning_content"] = s
+					} else {
+						delete(delta, "reasoning_content")
+					}
+				}
+			}
+		}
+		raw, err := json.Marshal(normalizeFrame(base))
+		if err != nil {
+			return err
+		}
+		base, hasC, hasR = nil, false, false
+		sbC.Reset()
+		sbR.Reset()
+		if _, werr := io.WriteString(w, "data: "+string(raw)+"\n\n"); werr != nil {
+			return werr
+		}
+		if fl != nil {
+			fl.Flush()
+		}
+		return nil
+	}
+
+	// mergeable 判断帧能否并入批次：仅含 content/reasoning_content 的普通 delta 帧，
+	// finish_reason/usage/tool_calls/function_call 帧一律透传。
+	mergeable := func(payload string) (map[string]any, bool) {
+		var obj map[string]any
+		if json.Unmarshal([]byte(payload), &obj) != nil {
+			return nil, false
+		}
+		if u, has := obj["usage"]; has && u != nil {
+			return nil, false
+		}
+		chs, ok := obj["choices"].([]any)
+		if !ok || len(chs) == 0 {
+			return nil, false
+		}
+		ch0, ok := chs[0].(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		if fr, ok := ch0["finish_reason"].(string); ok && fr != "" {
+			return nil, false
+		}
+		delta, ok := ch0["delta"].(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		// 空 tool_calls 列表（上游每帧都带 "tool_calls":[]）不算工具帧
+		if tcs, has := delta["tool_calls"]; has {
+			if list, ok := tcs.([]any); ok {
+				if len(list) > 0 {
+					return nil, false
+				}
+			} else if tcs != nil {
+				return nil, false
+			}
+		}
+		if fc, has := delta["function_call"]; has && fc != nil {
+			return nil, false
+		}
+		_, hc := delta["content"].(string)
+		_, hr := delta["reasoning_content"].(string)
+		if !hc && !hr {
+			return nil, false
+		}
+		return obj, true
+	}
+
+	writePassthrough := func(payload string) error {
+		if _, werr := io.WriteString(w, "data: "+payload+"\n\n"); werr != nil {
+			return werr
+		}
+		if fl != nil {
+			fl.Flush()
+		}
+		return nil
+	}
+
 	br := bufio.NewReaderSize(r, 64*1024)
-	sawDone := false
 	for {
 		line, err := br.ReadString('\n')
-		if line != "" {
-			if strings.HasPrefix(strings.TrimRight(line, "\r\n"), "data: [DONE]") {
-				sawDone = true
+		trimmed := strings.TrimRight(line, "\r\n")
+		switch {
+		case strings.HasPrefix(trimmed, "data: [DONE]"):
+			if ferr := flush(); ferr != nil {
+				return ferr
+			}
+			sawDone = true
+			if werr := writePassthrough("[DONE]"); werr != nil {
+				return werr
+			}
+		case strings.HasPrefix(trimmed, "data: "):
+			payload := strings.TrimPrefix(trimmed, "data: ")
+			if obj, ok := mergeable(payload); ok {
+				// 冲刷策略：逐帧即发（平滑流式）。规范化已剥空 content 噪声，
+				// TUI 不再因帧边界断行；切换点（思考↔回答）由下一帧冲刷保证顺序。
+				if base != nil {
+					if ferr := flush(); ferr != nil {
+						return ferr
+					}
+				}
+				if base == nil {
+					base = obj
+				}
+				if chs, ok := obj["choices"].([]any); ok && len(chs) > 0 {
+					if ch0, ok := chs[0].(map[string]any); ok {
+						delta, _ := ch0["delta"].(map[string]any)
+						if c, ok := delta["content"].(string); ok && c != "" {
+							hasC = true
+							sbC.WriteString(c)
+						}
+						if rc, ok := delta["reasoning_content"].(string); ok && rc != "" {
+							hasR = true
+							sbR.WriteString(rc)
+						}
+					}
+				}
+			} else {
+				if ferr := flush(); ferr != nil {
+					return ferr
+				}
+				// 透传帧同样按规范白名单重建（finish/usage/tool_calls 帧等）
+				var pobj map[string]any
+				if json.Unmarshal([]byte(payload), &pobj) == nil {
+					praw, err := json.Marshal(normalizeFrame(pobj))
+					if err == nil {
+						payload = string(praw)
+					}
+				}
+				if werr := writePassthrough(payload); werr != nil {
+					return werr
+				}
+			}
+		case trimmed != "":
+			// 注释/其他行：冲刷待批后原样透传
+			if ferr := flush(); ferr != nil {
+				return ferr
 			}
 			if _, werr := io.WriteString(w, line); werr != nil {
 				return werr
@@ -213,12 +457,16 @@ func Stream(w http.ResponseWriter, r io.Reader) error {
 				fl.Flush()
 			}
 		}
+		// 空行（帧分隔）吞掉：本函数自产 "\n\n"
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
 			return err
 		}
+	}
+	if ferr := flush(); ferr != nil {
+		return ferr
 	}
 	if !sawDone {
 		if _, err := io.WriteString(w, "data: [DONE]\n\n"); err != nil {


### PR DESCRIPTION
## 概述

三处代理层改进，全部集中在 `internal/upstream`，不改配置、不改对外 API 形态。起因是用 opencode / DSH 等客户端接入时遇到两个真实问题。

## 1. reasoning_effort 自动降级 (`client.go` + `payload.go`)

**问题**：opencode 等客户端会对所有模型统一发 `reasoning_effort: xhigh`，但 `hy4-preview` 只支持 `high`，上游直接返回 400。

**方案**：
- `FetchModels` 解析每个模型的 `reasoning.supportedEfforts` 并缓存到 `Client.efforts`
- 新增 `PrepareBodyOptWithEfforts`：仅当请求**显式携带** `reasoning_effort` 且模型不支持该档时，降级到 **≤请求档的最高支持档**（支持档全高于请求档则取最低档）
- 档位序 `off < minimal < low < medium < high < xhigh < max`
- 未知模型 / 未知档位 / 未携带该字段 → **原样透传**，零副作用
- `PrepareBodyOpt` 保持向后兼容（内部调用 `WithEfforts(nil)`）

## 2. OpenAI 规范化 SSE 帧 (`sse.go` `Stream`)

**问题**：上游帧带 `content:""`、空 `tool_calls:[]`、`finish_reason:""`、占位 `function_call:{name:"",arguments:""}` 等噪声字段，部分客户端把每个带空 `content` 的帧当独立 text part 渲染，表现为**思考内容一词一行**。

**方案**：`Stream` 白名单重建每一帧——顶层只留 `id/object/created/model/choices/usage`，`finish_reason:"" → null`，delta 只保留非空标准字段，剥掉空串/空列表/占位 `function_call`/未知字段。

## 3. 逐帧流式保持

规范化后逐 token 透传，不做批量攒帧，保持与上游一致的平滑流式。

## 验证

`go build ./...`、`go vet ./internal/upstream/`、`go test ./internal/upstream/` 全过（含新增逻辑）。已在生产环境（多账号池 + Docker）连续运行验证 opencode / DSH 双客户端接入正常。
