### PR TITLE
fix(login.sh): 变量紧跟全角字符导致 unbound variable（登录必败）+ API_KEY 未定义

### DIFF
--- a/login.sh
+++ b/login.sh
@@ -111,10 +111,10 @@ PYEOF
 # ─── 落盘 auth 文件（与 internal/auth 读取格式一致）─────────────────
 AUTH_FILE="$AUTH_DIR/workbuddy-${USER_ID}.json"
 if [[ -f "$AUTH_FILE" ]]; then
-    echo "账号已存在（uid=$USER_ID），将覆盖更新凭证"
+    echo "账号已存在（uid=${USER_ID}），将覆盖更新凭证"
     ACTION="覆盖"
 else
-    echo "新账号（uid=$USER_ID），新增 auth 文件"
+    echo "新账号（uid=${USER_ID}），新增 auth 文件"
     ACTION="新增"
 fi
 python3 - <<PYEOF
@@ -135,7 +135,7 @@ auth = {
 }
 with open("$AUTH_FILE", "w") as f:
     json.dump(auth, f, indent=1)
-print(f"已保存（$ACTION）: $AUTH_FILE")
+print(f"已保存（${ACTION}）: $AUTH_FILE")
 PYEOF
 
 # ─── 重启服务 ────────────────────────────────────────────
@@ -144,6 +144,8 @@ if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER}$"; then
     echo "重启 $CONTAINER 加载新账号..."
     docker restart "$CONTAINER" >/dev/null
     sleep 2
+    # API_KEY 从 config.json 读取（该变量在脚本中未定义，fallback 硬编码值会导致 401）
+    API_KEY=$(python3 -c "import json; print(json.load(open('config.json')).get('api_key',''))" 2>/dev/null)
     COUNT=$(curl -s http://127.0.0.1:7863/status -H "Authorization: Bearer ${API_KEY:-tistzach}" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('accounts',[])))" 2>/dev/null || echo "?")
     echo "服务已重启，当前账号数: $COUNT"
 else


### PR DESCRIPTION
## 问题

### 问题一：任何新账号登录必败（严重）

运行 `./login.sh` 登录新账号，签到成功后脚本在 line 117 中断：

```
签到: 今天已签到，请明天再来
./login.sh: line 117: USER_ID: unbound variable
```

**后果**：签到已执行但脚本死亡，auth 文件无法落盘，凭证丢失，用户只能反复重试。

**根因**：bash 5.x 在 UTF-8 locale 下，`$VAR` 后面**紧跟全角字符**时，全角字符的字节会被并入变量名。`set -u` 下立即报 unbound variable：

```bash
# 复现（bash 5.3.12 / macOS）：
$ bash -c 'set -u; USER_ID=abc; echo "新账号（uid=$USER_ID），测试"'
bash: 行 1: USER_ID: 未绑定的变量        # ❌「）」被并入变量名

$ bash -c 'set -u; USER_ID=abc; echo "新账号（uid=${USER_ID}），测试"'
新账号（uid=abc），测试                   # ✅ 大括号写法正常
```

文件中共 3 处同类写法（line 114 / 117 / 138），全部修复为 `${VAR}`。

### 问题二：API_KEY 引用了从未定义的变量（次要）

line 147 的 `${API_KEY:-tistzach}`：`API_KEY` 在脚本中从未定义，永远 fallback 到硬编码值。该 fallback 值是作者本机的 key（已进入开源仓库），用户修改过 config.json 的 `api_key` 后此处必然 401，重启后「当前账号数」恒显示 0。

修复：从 config.json 读取，保留原 fallback 兜底。

## 改动范围

仅 `login.sh`，+5/-3 行：

| 行 | 改动 |
|---|---|
| 114 | `$USER_ID` → `${USER_ID}` |
| 117 | `$USER_ID` → `${USER_ID}` |
| 138 | `$ACTION` → `${ACTION}` |
| 147 | 新增 `API_KEY=$(python3 -c ...)` 从 config.json 读取 |

不碰任何其他代码。（`python3` 与脚本既有 11 处依赖一致，无新增环境要求）

## 测试

- ✅ `bash -n login.sh` 语法通过
- ✅ 最小复现：`$VAR`+全角字符 → unbound variable（与用户报错完全一致，含乱码字符）
- ✅ 修复后对照测试 3 组全通过
- ✅ 真实端到端：新账号 OAuth 登录 → auth 文件成功落盘（`新账号（uid=...），新增 auth 文件` → `已保存（新增）`）→ 服务加载 → `/v1/chat/completions` 返回 200
- ✅ 多账号验证：2 个账号均加载，动态模型列表 15 个正常返回
- ✅ API_KEY 修复模拟测试：「当前账号数」从 0 → 2（与实际账号数一致）
- ✅ python3 缺失场景降级测试：fallback 生效，脚本不崩溃（保持老行为）

## 附注

此前提交的 issue #17（token 截断）根因判断有误，已自行关闭并附勘误。本 PR 才是实测确认的真实问题。