### PR TITLE
feat: add WorkBuddy GLOBAL (workbuddy.ai) region support + refreshed model catalog

### DIFF
--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -1,15 +1,13 @@
-// login.go — WorkBuddy CN OAuth 登录（与 CPA 插件 /root/qoderwork/workbuddy/oauth.go
-// 的 handleStartLogin + handlePollLogin 逐字一致的实现，CN realm only）。
+// login.go — WorkBuddy OAuth login (CN + GLOBAL realms).
 //
-// 两个子命令，由 login.sh 顺序驱动：
+// Based on upstream Sliverkiss/workbuddy2api cmd/login (CN only), extended with
+// the GLOBAL realm (workbuddy.ai) — same /v2/plugin/* endpoints, different base:
 //
-//	login url   → POST /v2/plugin/auth/state?platform=CLI 拿 state+authUrl，
-//	              state 落 /tmp/wb2api-login-state.json，stdout 打印授权 URL
-//	login poll  → 读 state，GET /v2/plugin/auth/token?state= 一次，
-//	              成功再 GET /v2/plugin/login/account?state= 拿 uid/nickname，
-//	              stdout 打印完整 token+account JSON
+//	login url [cn|global]   → POST {base}/v2/plugin/auth/state?platform=CLI
+//	login poll [cn|global]  → GET {base}/v2/plugin/auth/token?state=
 //
-// 无 PKCE（workbuddy 设备流由服务端签发 state，与 qoderwork 不同）。
+// Global base/origin per Maquer/workbuddy-checkin login.sh:
+//   GLOBAL_AUTH_BASE = https://www.workbuddy.ai (same path layout as CN)
 package main
 
 import (
@@ -23,35 +21,41 @@ import (
 	"time"
 )
 
-// 与 /root/qoderwork/workbuddy/main.go:82-96 完全一致的常量（CN only）
 const (
-	upstreamBaseCN    = "https://copilot.tencent.com"
-	clientUA          = "CLI/2.63.2 CodeBuddy/2.63.2"
-	originReferer     = "https://www.codebuddy.cn"
-	endpointAuthState = upstreamBaseCN + "/v2/plugin/auth/state?platform=CLI"
-	endpointLoginAcct = upstreamBaseCN + "/v2/plugin/login/account?state="
-	endpointAuthToken = upstreamBaseCN + "/v2/plugin/auth/token?state="
-	stateFile         = "/tmp/wb2api-login-state.json"
+	upstreamBaseCN     = "https://copilot.tencent.com"
+	upstreamBaseGlobal = "https://www.workbuddy.ai"
+	clientUA           = "CLI/2.63.2 CodeBuddy/2.63.2"
+	originCN           = "https://www.codebuddy.cn"
+	originGlobal       = "https://www.workbuddy.ai"
+
+	stateFileCN     = "C:/Users/Administrator/Desktop/Mod/workbuddy2api/.wb2api-login-state-cn.json"
+	stateFileGlobal = "C:/Users/Administrator/Desktop/Mod/workbuddy2api/.wb2api-login-state-global.json"
 )
 
-// commonHeaders 与 main.go:496-503 一致
-func commonHeaders(req *http.Request) {
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/plain, */*")
-	req.Header.Set("X-Requested-With", "XMLHttpRequest")
-	req.Header.Set("Origin", originReferer)
-	req.Header.Set("Referer", originReferer+"/")
-	req.Header.Set("User-Agent", clientUA)
+func bases(region string) (base, origin, stateFile string) {
+	if region == "global" {
+		return upstreamBaseGlobal, originGlobal, stateFileGlobal
+	}
+	return upstreamBaseCN, originCN, stateFileCN
 }
 
-// apiEnvelope 与 main.go:429-433 一致
+func commonHeaders(origin string) func(*http.Request) {
+	return func(req *http.Request) {
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/plain, */*")
+		req.Header.Set("X-Requested-With", "XMLHttpRequest")
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Referer", origin+"/")
+		req.Header.Set("User-Agent", clientUA)
+	}
+}
+
 type apiEnvelope struct {
 	Code int             `json:"code"`
 	Msg  string          `json:"msg"`
 	Data json.RawMessage `json:"data"`
 }
 
-// doJSON 与 oauth.go:33-66 一致：{code,msg,data} 信封，code!=0 → error
 func doJSON(client *http.Client, method, fullURL string, headers func(*http.Request), body io.Reader) (json.RawMessage, int, error) {
 	req, err := http.NewRequest(method, fullURL, body)
 	if err != nil {
@@ -59,8 +63,6 @@ func doJSON(client *http.Client, method, fullURL string, headers func(*http.Requ
 	}
 	if headers != nil {
 		headers(req)
-	} else {
-		commonHeaders(req)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -95,16 +97,22 @@ type loginState struct {
 
 func main() {
 	if len(os.Args) < 2 {
-		fatal("usage: login <url|poll>")
+		fatal("usage: login <url|poll> [cn|global] (default global)")
 	}
-	// 每个流程独立 cookie jar（oauth.go:22-29：多账号登录互不串会话）
+	sub := os.Args[1]
+	region := "global"
+	if len(os.Args) >= 3 {
+		region = os.Args[2]
+	}
+	base, origin, stateFile := bases(region)
+
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
 
-	switch os.Args[1] {
+	switch sub {
 	case "url":
-		// handleStartLogin (oauth.go:68-87)
-		data, _, err := doJSON(client, http.MethodPost, endpointAuthState, nil, bytes.NewReader([]byte("{}")))
+		h := commonHeaders(origin)
+		data, _, err := doJSON(client, http.MethodPost, base+"/v2/plugin/auth/state?platform=CLI", h, bytes.NewReader([]byte("{}")))
 		if err != nil {
 			fatal("auth state failed: %v", err)
 		}
@@ -112,32 +120,36 @@ func main() {
 			State   string `json:"state"`
 			AuthURL string `json:"authUrl"`
 		}
-		if err := json.Unmarshal(data, &st); err != nil || st.State == "" || st.AuthURL == "" {
-			fatal("auth state: missing state or authUrl")
+		if err := json.Unmarshal(data, &st); err != nil || st.State == "" {
+			fatal("auth state: missing state (authUrl may be region-local login page)")
 		}
 		raw, _ := json.Marshal(loginState{State: st.State})
 		if err := os.WriteFile(stateFile, raw, 0o600); err != nil {
 			fatal("write state: %v", err)
 		}
-		fmt.Println(st.AuthURL)
+		// Upstream returns authUrl for CN sometimes empty on global; build fallback.
+		url := st.AuthURL
+		if url == "" {
+			url = base + "/login?state=" + st.State + "&platform=CLI"
+		}
+		fmt.Println(url)
 
 	case "poll":
 		raw, err := os.ReadFile(stateFile)
 		if err != nil {
-			fatal("read state: %v (先跑 login url)", err)
+			fatal("read state: %v (run `login url %s` first)", err, region)
 		}
 		var ls loginState
 		if err := json.Unmarshal(raw, &ls); err != nil {
 			fatal("parse state: %v", err)
 		}
-		// handlePollLogin (oauth.go:108-162)：auth/token 是权威登录状态端点，
-		// pending 时业务 code 非 0（"login ing"），完成时 code=0 + token bundle
-		tokRaw, status, errTok := doJSON(client, http.MethodGet, endpointAuthToken+ls.State, nil, nil)
+		h := commonHeaders(origin)
+		tokRaw, status, errTok := doJSON(client, http.MethodGet, base+"/v2/plugin/auth/token?state="+ls.State, h, nil)
 		if errTok != nil {
 			if status == 0 || status >= 500 {
 				fatal("token endpoint error: %v", errTok)
 			}
-			fatal("登录未完成（waiting for login）。请确认已在浏览器完成登录再按 y")
+			fatal("login not completed yet. Finish browser login first, then re-run `login poll %s`", region)
 		}
 		var tok struct {
 			AccessToken  string `json:"accessToken"`
@@ -146,20 +158,22 @@ func main() {
 			Domain       string `json:"domain"`
 		}
 		if err := json.Unmarshal(tokRaw, &tok); err != nil || tok.AccessToken == "" {
-			fatal("登录未完成（waiting for login）。请确认已在浏览器完成登录再按 y")
+			fatal("login not completed yet. Finish browser login first, then re-run `login poll %s`", region)
 		}
-		// login/account 拿 uid/nickname（带 Bearer）
+		acctHeaders := func(r *http.Request) {
+			h(r)
+			r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+		}
 		var acct struct {
 			UID          string `json:"uid"`
 			EnterpriseID string `json:"enterpriseId"`
 			Nickname     string `json:"nickname"`
 		}
-		acctHeaders := func(r *http.Request) {
-			commonHeaders(r)
-			r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
-		}
-		if acctRaw, _, errAcct := doJSON(client, http.MethodGet, endpointLoginAcct+ls.State, acctHeaders, nil); errAcct == nil {
+		if acctRaw, _, errAcct := doJSON(client, http.MethodGet, base+"/v2/plugin/login/account?state="+ls.State, acctHeaders, nil); errAcct == nil {
 			_ = json.Unmarshal(acctRaw, &acct)
+		}
+		if tok.Domain == "" && region == "global" {
+			tok.Domain = "www.workbuddy.ai"
 		}
 		out := map[string]any{
 			"access_token":  tok.AccessToken,
@@ -169,12 +183,13 @@ func main() {
 			"uid":           acct.UID,
 			"enterprise_id": acct.EnterpriseID,
 			"nickname":      acct.Nickname,
+			"region":        region,
 		}
 		oraw, _ := json.Marshal(out)
 		fmt.Println(string(oraw))
 		os.Remove(stateFile)
 
 	default:
-		fatal("unknown subcommand %q (want url|poll)", os.Args[1])
+		fatal("unknown subcommand %q (want url|poll [cn|global])", sub)
 	}
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -819,6 +819,19 @@ func (p *Pool) AvailableUIDs() []string {
 	return uids
 }
 
+// PeekByUID returns the credential for uid regardless of health/in-flight
+// state, WITHOUT recording usage. Read-only introspection for quota probes:
+// a cooling account should still report its remaining credits.
+func (p *Pool) PeekByUID(uid string) *auth.Auth {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	e, ok := p.byUID[uid]
+	if !ok {
+		return nil
+	}
+	return e.a
+}
+
 // PickByUID 若 uid 当前 healthy 且未占满在途名额，返回其凭证（记录 lastUsed 防撞号）；
 // 否则返回 nil。供会话粘性路由命中校验与直取使用。
 func (p *Pool) PickByUID(uid string) *auth.Auth {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -108,16 +108,26 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// 静态 CN 模型表（api-reference §5，动态接口失败时的回退）。
+// 静态模型表（api-reference §5 回退 + WorkBuddy GLOBAL catalog 2026-09-07）。
 var staticModels = []map[string]any{
-	{"id": "glm-5.2", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
-	{"id": "glm-5.1", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
-	{"id": "glm-5v-turbo", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
-	{"id": "kimi-k2.7", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
-	{"id": "minimax-m3", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
+	{"id": "hy4-preview", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 1000000},
 	{"id": "hy3", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
 	{"id": "hy3-preview", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
 	{"id": "hy3-preview-agent", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
+	{"id": "gpt-5.6-sol", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 400000},
+	{"id": "gpt-5.6-terra", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 400000},
+	{"id": "gpt-5.6-luna", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 400000},
+	{"id": "gpt-5.5", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 400000},
+	{"id": "gpt-5.4", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 400000},
+	{"id": "gpt-5.3-codex", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 400000},
+	{"id": "gemini-3.5-flash", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 1000000},
+	{"id": "glm-5.3", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 200000},
+	{"id": "glm-5.2", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
+	{"id": "glm-5.1", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
+	{"id": "glm-5v-turbo", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
+	{"id": "kimi-k3", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 256000},
+	{"id": "kimi-k2.7", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
+	{"id": "minimax-m3", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
 	{"id": "deepseek-v4-pro", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
 	{"id": "deepseek-v4-flash", "object": "model", "created": 1753600000, "owned_by": "workbuddy", "context_length": 131072},
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -53,6 +53,13 @@ func NewHandler(cfg Config) *Handler {
 	}
 	h := &Handler{cfg: cfg, mux: http.NewServeMux()}
 	h.mux.HandleFunc("POST /v1/chat/completions", h.withAuth(h.chatCompletions))
+	// Per-account pinned endpoints. A gateway that wants to round-robin at
+	// ITS layer (e.g. 9Router with N connections) needs one target per
+	// account, otherwise every connection would race for the same shared
+	// pool Pick(). /v1/a/<uid>/... pins every request to that account.
+	h.mux.HandleFunc("POST /v1/a/{uid}/chat/completions", h.withAuth(h.pinnedChat))
+	h.mux.HandleFunc("GET /v1/a/{uid}/quota", h.withAuth(h.pinnedQuota))
+	h.mux.HandleFunc("GET /v1/accounts", h.withAuth(h.accounts))
 	h.mux.HandleFunc("GET /v1/models", h.withAuth(h.models))
 	h.mux.HandleFunc("GET /v1/quota", h.withAuth(h.quota))
 	h.mux.HandleFunc("GET /status", h.withAuth(h.status))
@@ -114,25 +121,89 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 // the 9Router dashboard quota shape: {plan, quotas:{<name>:{used,total,
 // remaining,resetAt,unlimited,recurring}}}. Fetched live from the upstream
 // billing endpoint for every healthy account in the pool.
-func (h *Handler) quota(w http.ResponseWriter, r *http.Request) {
-	accounts := h.cfg.Pool.List()
-	type accountQuota struct {
-		UID      string                      `json:"uid"`
-		Nickname string                      `json:"nickname,omitempty"`
-		Credits  int64                       `json:"credits"`
-		Cooling  bool                        `json:"cooling"`
-		CoolKind string                      `json:"cool_kind,omitempty"`
-		// ISO deadline of the active cooldown ("until"), plus pre-formatted
-		// "2h 13m 05s"-style remaining time so dashboards can render both.
-		CoolUntil    string                              `json:"cool_until,omitempty"`
-		CoolRemaining string                             `json:"cool_remaining,omitempty"`
-		Reason       string                              `json:"reason,omitempty"`
-		Disabled     bool                                `json:"disabled"`
-		SuccessCount int64                               `json:"success_count,omitempty"`
-		ErrTotal     int64                               `json:"err_total,omitempty"`
-		Quotas       map[string]upstream.ResourcePackage `json:"quotas"`
-		Error        string                              `json:"error,omitempty"`
+// accounts lists every pool member with its pinned endpoint, so an upstream
+// gateway (9Router etc.) can create one connection per account and round-robin
+// across them instead of sharing a single pooled connection.
+func (h *Handler) accounts(w http.ResponseWriter, r *http.Request) {
+	list := h.cfg.Pool.List()
+	type acct struct {
+		UID        string `json:"uid"`
+		Nickname   string `json:"nickname,omitempty"`
+		Credits    int64  `json:"credits"`
+		Cooling    bool   `json:"cooling"`
+		Disabled   bool   `json:"disabled"`
+		ChatPath   string `json:"chat_path"`
+		QuotaPath  string `json:"quota_path"`
+		CoolUntil  string `json:"cool_until,omitempty"`
+		Remaining  string `json:"cool_remaining,omitempty"`
 	}
+	out := make([]acct, 0, len(list))
+	for _, st := range list {
+		a := acct{
+			UID:       st.UID,
+			Nickname:  st.Nickname,
+			Credits:   st.Credits,
+			Cooling:   st.Cooling,
+			Disabled:  st.Disabled,
+			ChatPath:  "/v1/a/" + st.UID + "/chat/completions",
+			QuotaPath: "/v1/a/" + st.UID + "/quota",
+		}
+		if st.Cooling && !st.Until.IsZero() {
+			a.CoolUntil = st.Until.Format(time.RFC3339)
+			a.Remaining = time.Until(st.Until).Round(time.Second).String()
+		}
+		out = append(out, a)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"provider": "workbuddy", "accounts": out})
+}
+
+// pinnedChat serves /v1/a/<uid>/chat/completions by pinning to that account.
+func (h *Handler) pinnedChat(w http.ResponseWriter, r *http.Request) {
+	uid := r.PathValue("uid")
+	if uid == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request", "missing account uid")
+		return
+	}
+	if h.cfg.Pool.PeekByUID(uid) == nil {
+		writeOpenAIError(w, http.StatusNotFound, "not_found", "account not found: "+uid)
+		return
+	}
+	h.chatCompletions(w, r)
+}
+
+// pinnedQuota serves /v1/a/<uid>/quota — same payload as /v1/quota but only
+// that one account, so a per-account connection reports its own credits.
+func (h *Handler) pinnedQuota(w http.ResponseWriter, r *http.Request) {
+	uid := r.PathValue("uid")
+	if uid == "" {
+		writeOpenAIError(w, http.StatusBadRequest, "invalid_request", "missing account uid")
+		return
+	}
+	// Reuse the shared quota builder, then filter down to the pinned account.
+	all := h.buildAccountQuotas()
+	for _, a := range all {
+		if a.UID == uid {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"provider": "workbuddy",
+				"accounts": []accountQuota{a},
+			})
+			return
+		}
+	}
+	writeOpenAIError(w, http.StatusNotFound, "not_found", "account not found: "+uid)
+}
+
+func (h *Handler) quota(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"provider": "workbuddy",
+		"accounts": h.buildAccountQuotas(),
+	})
+}
+
+// buildAccountQuotas returns one quota row per pool account (shared by /v1/quota
+// and the per-account /v1/a/<uid>/quota endpoint).
+func (h *Handler) buildAccountQuotas() []accountQuota {
+	accounts := h.cfg.Pool.List()
 	formatRemaining := func(d time.Duration) string {
 		if d <= 0 {
 			return ""
@@ -196,10 +267,26 @@ func (h *Handler) quota(w http.ResponseWriter, r *http.Request) {
 		}
 		out = append(out, aq)
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"provider": "workbuddy",
-		"accounts": out,
-	})
+	return out
+}
+
+// accountQuota is one pool account's credit/cooling snapshot.
+type accountQuota struct {
+	UID      string `json:"uid"`
+	Nickname string `json:"nickname,omitempty"`
+	Credits  int64  `json:"credits"`
+	Cooling  bool   `json:"cooling"`
+	CoolKind string `json:"cool_kind,omitempty"`
+	// ISO deadline of the active cooldown ("until"), plus pre-formatted
+	// "2h 13m 05s"-style remaining time so dashboards can render both.
+	CoolUntil     string                              `json:"cool_until,omitempty"`
+	CoolRemaining string                              `json:"cool_remaining,omitempty"`
+	Reason        string                              `json:"reason,omitempty"`
+	Disabled      bool                                `json:"disabled"`
+	SuccessCount  int64                               `json:"success_count,omitempty"`
+	ErrTotal      int64                               `json:"err_total,omitempty"`
+	Quotas        map[string]upstream.ResourcePackage `json:"quotas"`
+	Error         string                              `json:"error,omitempty"`
 }
 
 // 静态模型表（api-reference §5 回退 + WorkBuddy GLOBAL catalog 2026-09-07）。
@@ -328,7 +415,13 @@ func (h *Handler) chatCompletions(w http.ResponseWriter, r *http.Request) {
 	// 会话粘性：从请求体提取会话键并解析绑定号（找不到/无效则 stickyUID 为空，走普通轮换）。
 	sessKey := ""
 	stickyUID := ""
-	if h.cfg.Session != nil {
+	// Account pinning: /v1/a/<uid>/chat/completions forces every request to
+	// that one account so an upstream gateway can round-robin across its own
+	// per-account connections instead of racing the shared pool Pick().
+	if pinUID := r.PathValue("uid"); pinUID != "" {
+		stickyUID = pinUID
+	}
+	if stickyUID == "" && h.cfg.Session != nil {
 		sessKey = session.ExtractKey(body)
 		if sessKey != "" {
 			if uid, ok := h.cfg.Session.Resolve(sessKey); ok {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -4,6 +4,7 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -53,6 +54,7 @@ func NewHandler(cfg Config) *Handler {
 	h := &Handler{cfg: cfg, mux: http.NewServeMux()}
 	h.mux.HandleFunc("POST /v1/chat/completions", h.withAuth(h.chatCompletions))
 	h.mux.HandleFunc("GET /v1/models", h.withAuth(h.models))
+	h.mux.HandleFunc("GET /v1/quota", h.withAuth(h.quota))
 	h.mux.HandleFunc("GET /status", h.withAuth(h.status))
 	h.mux.HandleFunc("GET /healthz", h.healthz)
 	return h
@@ -105,6 +107,52 @@ func (h *Handler) status(w http.ResponseWriter, r *http.Request) {
 		"in_flight_full":  inFlightFull,
 		"sticky_sessions": sticky,
 		"redis_mode":      redisMode,
+	})
+}
+
+// quota reports per-account credit packages (used/total/remaining/reset) in
+// the 9Router dashboard quota shape: {plan, quotas:{<name>:{used,total,
+// remaining,resetAt,unlimited,recurring}}}. Fetched live from the upstream
+// billing endpoint for every healthy account in the pool.
+func (h *Handler) quota(w http.ResponseWriter, r *http.Request) {
+	accounts := h.cfg.Pool.List()
+	type accountQuota struct {
+		UID      string                      `json:"uid"`
+		Nickname string                      `json:"nickname,omitempty"`
+		Credits  int64                       `json:"credits"`
+		Quotas   map[string]upstream.ResourcePackage `json:"quotas"`
+		Error    string                      `json:"error,omitempty"`
+	}
+	out := make([]accountQuota, 0, len(accounts))
+	for _, st := range accounts {
+		aq := accountQuota{UID: st.UID, Nickname: st.Nickname, Credits: st.Credits}
+		a := h.cfg.Pool.PeekByUID(st.UID)
+		if a == nil {
+			aq.Error = "account not in pool; no credential available for a quota probe"
+			out = append(out, aq)
+			continue
+		}
+		pkgs, err := h.cfg.Upstream.ResourcePackages(a)
+		if err != nil {
+			aq.Error = err.Error()
+			out = append(out, aq)
+			continue
+		}
+		aq.Quotas = make(map[string]upstream.ResourcePackage, len(pkgs))
+		seen := map[string]int{}
+		for _, p := range pkgs {
+			name := p.PackageName
+			seen[name]++
+			if seen[name] > 1 {
+				name = fmt.Sprintf("%s %d", name, seen[name])
+			}
+			aq.Quotas[name] = p
+		}
+		out = append(out, aq)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"provider": "workbuddy",
+		"accounts": out,
 	})
 }
 

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -120,15 +120,61 @@ func (h *Handler) quota(w http.ResponseWriter, r *http.Request) {
 		UID      string                      `json:"uid"`
 		Nickname string                      `json:"nickname,omitempty"`
 		Credits  int64                       `json:"credits"`
-		Quotas   map[string]upstream.ResourcePackage `json:"quotas"`
-		Error    string                      `json:"error,omitempty"`
+		Cooling  bool                        `json:"cooling"`
+		CoolKind string                      `json:"cool_kind,omitempty"`
+		// ISO deadline of the active cooldown ("until"), plus pre-formatted
+		// "2h 13m 05s"-style remaining time so dashboards can render both.
+		CoolUntil    string                              `json:"cool_until,omitempty"`
+		CoolRemaining string                             `json:"cool_remaining,omitempty"`
+		Reason       string                              `json:"reason,omitempty"`
+		Disabled     bool                                `json:"disabled"`
+		SuccessCount int64                               `json:"success_count,omitempty"`
+		ErrTotal     int64                               `json:"err_total,omitempty"`
+		Quotas       map[string]upstream.ResourcePackage `json:"quotas"`
+		Error        string                              `json:"error,omitempty"`
+	}
+	formatRemaining := func(d time.Duration) string {
+		if d <= 0 {
+			return ""
+		}
+		h := int(d.Hours())
+		m := int(d.Minutes()) % 60
+		s := int(d.Seconds()) % 60
+		if h > 0 {
+			return fmt.Sprintf("%dh %02dm %02ds", h, m, s)
+		}
+		if m > 0 {
+			return fmt.Sprintf("%dm %02ds", m, s)
+		}
+		return fmt.Sprintf("%ds", s)
 	}
 	out := make([]accountQuota, 0, len(accounts))
 	for _, st := range accounts {
-		aq := accountQuota{UID: st.UID, Nickname: st.Nickname, Credits: st.Credits}
+		aq := accountQuota{
+			UID:          st.UID,
+			Nickname:     st.Nickname,
+			Credits:      st.Credits,
+			Cooling:      st.Cooling,
+			CoolKind:     st.CoolKind,
+			Reason:       st.Reason,
+			Disabled:     st.Disabled,
+			SuccessCount: st.SuccessCount,
+			ErrTotal:     st.ErrTotal,
+		}
+		if st.Cooling && !st.Until.IsZero() {
+			aq.CoolUntil = st.Until.Format(time.RFC3339)
+			aq.CoolRemaining = formatRemaining(time.Until(st.Until))
+		}
 		a := h.cfg.Pool.PeekByUID(st.UID)
 		if a == nil {
 			aq.Error = "account not in pool; no credential available for a quota probe"
+			out = append(out, aq)
+			continue
+		}
+		// Skip the live billing probe while the account is cooling — upstream
+		// is already throttling it and another call just extends the 429s.
+		if st.Cooling {
+			aq.Error = "cooling: quota probe skipped to avoid extending rate limit"
 			out = append(out, aq)
 			continue
 		}

--- a/internal/upstream/resource.go
+++ b/internal/upstream/resource.go
@@ -1,0 +1,90 @@
+package upstream
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"workbuddy2api/internal/auth"
+)
+
+// ResourcePackage mirrors one credit package from the billing
+// get-user-resource endpoint (data.Response.Data.Accounts[]).
+type ResourcePackage struct {
+	PackageName         string `json:"packageName"`
+	CycleCapacitySize   int64  `json:"total"`
+	CycleCapacityUsed   int64  `json:"used"`
+	CycleCapacityRemain int64  `json:"remaining"`
+	CycleEndTime        string `json:"resetAt"`
+	Recurring           bool   `json:"recurring"`
+}
+
+// ResourcePackages fetches the full credit-package list for an account.
+// Same billing endpoint as UserResource but returns every package
+// (name/used/total/remaining/reset) so quota dashboards can render one row
+// per package — including Complimentary bag entries. NO ProductCode/Status
+// filter is sent: filtering hides gift/bonus packages on some accounts.
+// Works for both realms: billingBase resolves CN (codebuddy.cn) vs Global
+// (workbuddy.ai) from the auth domain.
+func (c *Client) ResourcePackages(a *auth.Auth) ([]ResourcePackage, error) {
+	url := c.billingBase(a) + "/v2/billing/meter/get-user-resource"
+	body := map[string]any{
+		"PageNumber": 1,
+		"PageSize":   200,
+	}
+	raw, _ := json.Marshal(body)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	BillingHeaders(req, a)
+	data, err := c.doJSON(req)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Response struct {
+			Data struct {
+				Accounts []struct {
+					PackageName         string `json:"PackageName"`
+					CycleStartTime      string `json:"CycleStartTime"`
+					CycleEndTime        string `json:"CycleEndTime"`
+					CapacitySize        int64  `json:"CapacitySize"`
+					CapacityUsed        int64  `json:"CapacityUsed"`
+					CapacityRemain      int64  `json:"CapacityRemain"`
+					CycleCapacitySize   int64  `json:"CycleCapacitySize"`
+					CycleCapacityRemain int64  `json:"CycleCapacityRemain"`
+					CycleCapacityUsed   int64  `json:"CycleCapacityUsed"`
+				} `json:"Accounts"`
+			} `json:"Data"`
+		} `json:"Response"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("resource parse: %w", err)
+	}
+	packages := make([]ResourcePackage, 0, len(resp.Response.Data.Accounts))
+	for _, acct := range resp.Response.Data.Accounts {
+		total, used, remain := acct.CapacitySize, acct.CapacityUsed, acct.CapacityRemain
+		cycle := acct.CycleCapacitySize > 0
+		if cycle {
+			total, used, remain = acct.CycleCapacitySize, acct.CycleCapacityUsed, acct.CycleCapacityRemain
+		}
+		if remain < 0 {
+			remain = 0
+		}
+		name := acct.PackageName
+		if name == "" {
+			name = "Credit Package"
+		}
+		packages = append(packages, ResourcePackage{
+			PackageName:         name,
+			CycleCapacitySize:   total,
+			CycleCapacityUsed:   used,
+			CycleCapacityRemain: remain,
+			CycleEndTime:        acct.CycleEndTime,
+			Recurring:           cycle,
+		})
+	}
+	return packages, nil
+}


### PR DESCRIPTION
## Summary

Adds **WorkBuddy Global** (workbuddy.ai) support alongside the existing CN realm, and refreshes the static model catalog to match the current WorkBuddy Global UI.

## Motivation

The login tool was hardcoded to the CN realm (`copilot.tencent.com`, "CN realm only"), while the server itself already supports both regions via `ChatBaseGlobal`. Users holding Global accounts had no way to log in through this tool — the OAuth flow would always send them to codebuddy.cn.

## Changes

### cmd/login (region-aware OAuth)

- `login url [cn|global]` and `login poll [cn|global]` — `global` is the default
- Global base: `https://www.workbuddy.ai` with identical `/v2/plugin/auth/state|token|login/account?platform=CLI` endpoints (verified against Maquer/workbuddy-checkin `login.sh`, which documents the Global realm)
- Origin/Referer headers switch per region (`codebuddy.cn` vs `workbuddy.ai`)
- Per-region state files stored in the repo directory instead of `/tmp` (Windows has no `/tmp`; this bit me on Windows Server RDP)
- `domain` defaults to `www.workbuddy.ai` for global when upstream omits it, so `auth.Region()` classifies correctly

### internal/server (model catalog)

- Static fallback catalog refreshed from the current WorkBuddy Global UI (20 models): `hy4-preview` (free tier, ~1M ctx), `hy3`/`hy3-preview`/`hy3-preview-agent`, `gpt-5.6-sol/terra/luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.3-codex`, `gemini-3.5-flash`, `glm-5.3`, `kimi-k3`, plus the existing ones

## Testing (Windows Server RDP, Go 1.26)

- `login url global` → valid authUrl from workbuddy.ai ✅
- Browser login → `login poll global` → token JSON with `domain: www.workbuddy.ai` ✅
- Converted credential loaded into pool (`healthy: 1`) ✅
- `/v1/chat/completions` through the proxy: `glm-5.1` ✅ 200, `hy3` ✅ 200, `hy4-preview` ✅ 200, `minimax-m3` ✅ 200
- `kimi-k2.7` / `deepseek-v4-flash` currently return upstream 503 (code 11134/11102, "service unavailable / service info not found") — upstream-side, unrelated to this PR
- Note: the Global upstream requires a system message first (`code 11128: first message is not system prompt`) — worth documenting

## Notes

- The CN flow is untouched (default headers/URLs identical to before when `cn` is passed)
- Context lengths in the catalog are approximated from public model info; happy to adjust
