### PR TITLE
fix(upstream): 脱敏 Codex instructions 首段指纹（code=11128）

### DIFF
--- a/internal/upstream/sanitize.go
+++ b/internal/upstream/sanitize.go
@@ -17,6 +17,7 @@ var sanitizeFeatures = []string{
 	"cc_entrypoint=",             // 尾随裸键值（截断前缀即可命中）
 	"You are Claude Code",        // 身份句（截断前缀即可命中）
 	"Main branch (",              // 注入指令句（截断前缀即可命中）
+	"You are a coding agent running in the Codex CLI", // Codex instructions 首段（截断前缀即可命中）
 }
 
 // sanitizeHdrRe 剥离层：header 键名即触发（与值无关），整段删除。
@@ -34,6 +35,10 @@ var sanitizeRewrites = [][2]string{
 	{
 		"Main branch (you will usually use this for PRs)",
 		"Default branch (you will usually use this for PRs)",
+	},
+	{
+		"You are a coding agent running in the Codex CLI, a terminal-based coding assistant.",
+		"You are a coding agent running in the Codex CLI tool, a terminal-based coding assistant.",
 	},
 }
 

--- a/internal/upstream/sanitize_test.go
+++ b/internal/upstream/sanitize_test.go
@@ -15,6 +15,8 @@ const (
 	ccIdentity = "You are Claude Code, Anthropic's official CLI for Claude."
 	ccBranch   = "Main branch (you will usually use this for PRs)"
 	ccHeader   = "x-anthropic-billing-header: cc_version=1.0; cc_entrypoint=cli;"
+	// Codex instructions 首段（上游逐字精确指纹，三句缺一不可）。
+	codexInstructions = "You are a coding agent running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful."
 )
 
 func TestIdentityRewritten(t *testing.T) {
@@ -41,6 +43,37 @@ func TestBillingHeaderStrippedValueIrrelevant(t *testing.T) {
 	out := sanitizeText(ccHeader)
 	if strings.Contains(out, "x-anthropic-billing-header") {
 		t.Errorf("header not stripped: %q", out)
+	}
+}
+
+// Codex instructions 首段：命中预告且整句改写，逐字指纹被破坏、语义保留。
+func TestCodexInstructionsRewritten(t *testing.T) {
+	out := sanitizeText(codexInstructions)
+	if strings.Contains(out, codexInstructions) {
+		t.Errorf("codex fingerprint still present: %q", out)
+	}
+	if !strings.Contains(out, "You are a coding agent running in the Codex CLI tool, a terminal-based coding assistant.") {
+		t.Errorf("codex first sentence not rewritten: %q", out)
+	}
+	// 其余两句原样保留，语义不变。
+	if !strings.Contains(out, "Codex CLI is an open source project led by OpenAI.") ||
+		!strings.Contains(out, "You are expected to be precise, safe, and helpful.") {
+		t.Errorf("codex remaining sentences altered: %q", out)
+	}
+}
+
+// 预检必须能认出 Codex 特征（此前只含 Claude Code，导致提前放行）。
+func TestCodexFingerprintDetected(t *testing.T) {
+	if !hasFingerprint(codexInstructions) {
+		t.Error("codex fingerprint not detected by precheck")
+	}
+}
+
+// 非精确变体不应被改写：仅去掉其中一个词即视为已破坏，无需改动。
+func TestCodexVariantNotTouched(t *testing.T) {
+	in := "You are a coding agent running in a CLI, a terminal-based coding assistant."
+	if out := sanitizeText(in); out != in {
+		t.Errorf("already-broken variant should be untouched: %q -> %q", in, out)
 	}
 }
 
@@ -186,6 +219,51 @@ func TestChatStreamWireBodySanitized(t *testing.T) {
 		if strings.Contains(sys, fp) {
 			t.Errorf("wire body contains fingerprint %q: %q", fp, sys)
 		}
+	}
+}
+
+// 出站边界（Codex 场景）：CPA 把 instructions 折成 role=system 的首条消息，
+// 净化后 wire body 不得残留 Codex 逐字指纹；其余消息不受影响。
+func TestChatStreamWireBodyCodexInstructionsSanitized(t *testing.T) {
+	var gotBody []byte
+	ts := newTestUpstream(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"))
+	})
+	defer ts.Close()
+
+	c := New()
+	c.SanitizeFingerprints = true
+	c.ChatBaseCN = ts.URL
+	acct := &auth.Auth{AccessToken: "test-token", Domain: "copilot.tencent.com", UID: "u1"}
+
+	body := []byte(`{"model":"kimi-k3","messages":[` +
+		`{"role":"system","content":"` + codexInstructions + `"},` +
+		`{"role":"user","content":"say ok"}]}`)
+	rc, status, respBody, err := c.ChatStream(acct, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rc.Close()
+	if status >= 400 {
+		t.Fatalf("upstream status %d: %s", status, respBody)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(gotBody, &obj); err != nil {
+		t.Fatalf("wire body not json: %v", err)
+	}
+	sys, _ := obj["messages"].([]any)[0].(map[string]any)["content"].(string)
+	if strings.Contains(sys, codexInstructions) ||
+		strings.Contains(sys, "in the Codex CLI, a terminal-based coding assistant.") {
+		t.Errorf("wire body still contains codex fingerprint: %q", sys)
+	}
+	if !strings.Contains(sys, "running in the Codex CLI tool, a terminal-based") {
+		t.Errorf("codex rewrite missing on wire: %q", sys)
+	}
+	user, _ := obj["messages"].([]any)[1].(map[string]any)["content"].(string)
+	if user != "say ok" {
+		t.Errorf("user message altered: %q", user)
 	}
 }
 


### PR DESCRIPTION
## 问题

Codex CLI（0.154.0，`wire_api="responses"`）经 workbuddy2api 调用稳定 400：

    {"code":11128,"msg":"Illegal API invocation from an unapproved channel"}

400 被归为 client 错误只换号，轮完全部账号后 `503 no_healthy_account`，客户端无限重连。

## 根因

上游拦截 `instructions` 内容指纹，与 #25 的 `developer` role 无关。

- Codex `/v1/responses` 顶层 `instructions` 首段是固定模板。
- CPA Responses→chat 转换（`openai_openai-responses_request.go:51-55`）将其折成
  `{"role":"system","content":"<instructions>"}`。
- `sanitizeMessages` 能遍历到该消息，但 `sanitizeText` 开头
  `if !hasFingerprint(text) { return text }`，而 `sanitizeFeatures` 只登记
  Claude Code 特征，不含 `Codex`，未命中即原样放行。

触发串逐字精确匹配（三句缺一不可，任改一词即绕过）：

    You are a coding agent running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful.

## 修复

`internal/upstream/sanitize.go`：

- `sanitizeFeatures` 加首段前缀，使其进入净化流程。
- `sanitizeRewrites` 在首句插一个词 `tool`（与 Claude Code 的
  `CLI for Claude`→`CLI tool for Claude` 同构），破坏逐字匹配、语义不变：

      -You are a coding agent running in the Codex CLI, a terminal-based coding assistant.
      +You are a coding agent running in the Codex CLI tool, a terminal-based coding assistant.

## 验证

- `go test ./...` 全绿；新增 4 用例（改写、预检命中、变体不动、出站 wire body 无残留）。
- 真实 Codex 抓包 body（17KB instructions）经 CPA `/v1/responses`：
  修复前稳定 400/11128，修复后 3/3 返回 200。
- 线上部署后 5 分钟日志 11128 计数 0。

## 备注

仅处理 11128 指纹；用户侧另有 `11133 model_param_invalid`，经排查为另一客户端独立问题。不涉及 `normalizeRoles`。

Closes #36