### PR TITLE
feat(gateway): 网关双域，CN/国际版混池

### DIFF
--- a/cmd/credit/main.go
+++ b/cmd/credit/main.go
@@ -22,10 +22,31 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 )
 
 const billingBaseCN = "https://www.codebuddy.cn"
+
+// billingBaseGlobal 国际版 billing base（与 chat 同域）。
+const billingBaseGlobal = "https://www.workbuddy.ai"
+
+// billingBaseFor 按 domain 后缀选 billing base（与 auth.IsGlobal 同规则）。
+func billingBaseFor(domain string) string {
+	if strings.HasSuffix(domain, ".workbuddy.ai") {
+		return billingBaseGlobal
+	}
+	return billingBaseCN
+}
+
+// billingPathForDomain 按 domain 后缀选 billing 路径：国际版经网关代理的相对
+// 路径 /billing/meter/*（/v2 前缀在 workbuddy.ai 上 404，实测 2026-09-12）。
+func billingPathForDomain(domain string) string {
+	if strings.HasSuffix(domain, ".workbuddy.ai") {
+		return "/billing/meter/get-user-resource"
+	}
+	return "/v2/billing/meter/get-user-resource"
+}
 
 type authFile struct {
 	Auth struct {
@@ -98,7 +119,7 @@ func fetchUserResource(af *authFile) (remain, used, size int64, packs int, err e
 		"PackageEndTimeRangeBegin": now.Format("2006-01-02 15:04:05"),
 		"PackageEndTimeRangeEnd":   now.Add(365 * 101 * 24 * time.Hour).Format("2006-01-02 15:04:05"),
 	})
-	req, err := http.NewRequest(http.MethodPost, billingBaseCN+"/v2/billing/meter/get-user-resource", bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, billingBaseFor(af.Auth.Domain)+billingPathForDomain(af.Auth.Domain), bytes.NewReader(body))
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}

--- a/cmd/login/main.go
+++ b/cmd/login/main.go
@@ -1,12 +1,16 @@
-// login.go — WorkBuddy CN OAuth 登录（设备授权流程，CN realm only）。
+// login.go — WorkBuddy CN + 国际版 OAuth 登录（设备授权流程，双 realm）。
 //
-// 两个子命令，由 login.sh 顺序驱动：
+// 两个子命令，由 login.sh 顺序驱动（加 --realm=cn|global，默认 cn）:
 //
-//	login url   → POST /v2/plugin/auth/state?platform=CLI 拿 state+authUrl，
-//	              state 落 /tmp/wb2api-login-state.json，stdout 打印授权 URL
-//	login poll  → 读 state，GET /v2/plugin/auth/token?state= 一次，
-//	              成功再 GET /v2/plugin/login/account?state= 拿 uid/nickname，
-//	              stdout 打印完整 token+account JSON
+//	login [--realm=global] url   → POST {base}/v2/plugin/auth/state?platform=CLI 拿 state+authUrl,
+//	                               state 落 /tmp/wb2api-login-state.json，stdout 打印授权 URL
+//	login [--realm=global] poll  → 读 state，GET {base}/v2/plugin/auth/token?state= 一次，
+//	                               成功再 GET {base}/v2/plugin/login/account?state= 拿 uid/nickname，
+//	                               stdout 打印完整 token+account JSON（含 realm 字段）
+//
+// CN：base=https://copilot.tencent.com，Origin=https://www.codebuddy.cn
+// 国际版：base=https://www.workbuddy.ai，Origin=https://www.workbuddy.ai
+// （实测国际版 auth/state + auth/token 与 CN 同路径同信封）
 //
 // 无 PKCE（workbuddy 设备流由服务端签发 state）。
 package main
@@ -14,6 +18,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,25 +27,34 @@ import (
 	"time"
 )
 
-// 上游常量（CN only）
+// 上游常量（双 realm：CN + 国际版）
 const (
-	upstreamBaseCN    = "https://copilot.tencent.com"
-	clientUA          = "CLI/2.63.2 CodeBuddy/2.63.2"
-	originReferer     = "https://www.codebuddy.cn"
-	endpointAuthState = upstreamBaseCN + "/v2/plugin/auth/state?platform=CLI"
-	endpointLoginAcct = upstreamBaseCN + "/v2/plugin/login/account?state="
-	endpointAuthToken = upstreamBaseCN + "/v2/plugin/auth/token?state="
-	stateFile         = "/tmp/wb2api-login-state.json"
+	upstreamBaseCN      = "https://copilot.tencent.com"
+	upstreamBaseGlobal  = "https://www.workbuddy.ai"
+	clientUA            = "CLI/2.63.2 CodeBuddy/2.63.2"
+	originRefererCN     = "https://www.codebuddy.cn"
+	originRefererGlobal = "https://www.workbuddy.ai"
+	stateFile           = "/tmp/wb2api-login-state.json"
 )
 
-// commonHeaders 通用请求头
-func commonHeaders(req *http.Request) {
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json, text/plain, */*")
-	req.Header.Set("X-Requested-With", "XMLHttpRequest")
-	req.Header.Set("Origin", originReferer)
-	req.Header.Set("Referer", originReferer+"/")
-	req.Header.Set("User-Agent", clientUA)
+// realmConfig 按 realm 返回 base + origin。
+func realmConfig(realm string) (base, origin string) {
+	if realm == "global" {
+		return upstreamBaseGlobal, originRefererGlobal
+	}
+	return upstreamBaseCN, originRefererCN
+}
+
+// commonHeaders 通用请求头（origin 按 realm 切换）。
+func commonHeaders(origin string) func(*http.Request) {
+	return func(req *http.Request) {
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/plain, */*")
+		req.Header.Set("X-Requested-With", "XMLHttpRequest")
+		req.Header.Set("Origin", origin)
+		req.Header.Set("Referer", origin+"/")
+		req.Header.Set("User-Agent", clientUA)
+	}
 }
 
 // apiEnvelope 与 main.go:429-433 一致
@@ -59,7 +73,7 @@ func doJSON(client *http.Client, method, fullURL string, headers func(*http.Requ
 	if headers != nil {
 		headers(req)
 	} else {
-		commonHeaders(req)
+		commonHeaders(originRefererCN)(req)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -90,20 +104,30 @@ func fatal(format string, args ...any) {
 
 type loginState struct {
 	State string `json:"state"`
+	Realm string `json:"realm,omitempty"`
 }
 
 func main() {
-	if len(os.Args) < 2 {
-		fatal("usage: login <url|poll>")
+	fs := flag.NewFlagSet("login", flag.ContinueOnError)
+	realm := fs.String("realm", "cn", "login realm: cn|global")
+	_ = fs.Parse(os.Args[1:])
+	rest := fs.Args()
+	if len(rest) < 1 {
+		fatal("usage: login [--realm=cn|global] <url|poll>")
 	}
+	base, origin := realmConfig(*realm)
+	headers := commonHeaders(origin)
+	endpointAuthState := base + "/v2/plugin/auth/state?platform=CLI"
+	endpointLoginAcct := base + "/v2/plugin/login/account?state="
+	endpointAuthToken := base + "/v2/plugin/auth/token?state="
 	// 每个流程独立 cookie jar（oauth.go:22-29：多账号登录互不串会话）
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Timeout: 30 * time.Second, Jar: jar}
 
-	switch os.Args[1] {
+	switch rest[0] {
 	case "url":
 		// handleStartLogin (oauth.go:68-87)
-		data, _, err := doJSON(client, http.MethodPost, endpointAuthState, nil, bytes.NewReader([]byte("{}")))
+		data, _, err := doJSON(client, http.MethodPost, endpointAuthState, headers, bytes.NewReader([]byte("{}")))
 		if err != nil {
 			fatal("auth state failed: %v", err)
 		}
@@ -114,7 +138,7 @@ func main() {
 		if err := json.Unmarshal(data, &st); err != nil || st.State == "" || st.AuthURL == "" {
 			fatal("auth state: missing state or authUrl")
 		}
-		raw, _ := json.Marshal(loginState{State: st.State})
+		raw, _ := json.Marshal(loginState{State: st.State, Realm: *realm})
 		if err := os.WriteFile(stateFile, raw, 0o600); err != nil {
 			fatal("write state: %v", err)
 		}
@@ -129,9 +153,13 @@ func main() {
 		if err := json.Unmarshal(raw, &ls); err != nil {
 			fatal("parse state: %v", err)
 		}
+		// url 与 poll 必须同 realm：poll 用 state 落盘时的 realm（防混域）。
+		if ls.Realm != "" && ls.Realm != *realm {
+			fatal("realm mismatch: url 用 --realm=%s，poll 也要用 --realm=%s", ls.Realm, ls.Realm)
+		}
 		// handlePollLogin (oauth.go:108-162)：auth/token 是权威登录状态端点，
 		// pending 时业务 code 非 0（"login ing"），完成时 code=0 + token bundle
-		tokRaw, status, errTok := doJSON(client, http.MethodGet, endpointAuthToken+ls.State, nil, nil)
+		tokRaw, status, errTok := doJSON(client, http.MethodGet, endpointAuthToken+ls.State, headers, nil)
 		if errTok != nil {
 			if status == 0 || status >= 500 {
 				fatal("token endpoint error: %v", errTok)
@@ -154,7 +182,7 @@ func main() {
 			Nickname     string `json:"nickname"`
 		}
 		acctHeaders := func(r *http.Request) {
-			commonHeaders(r)
+			headers(r)
 			r.Header.Set("Authorization", "Bearer "+tok.AccessToken)
 		}
 		if acctRaw, _, errAcct := doJSON(client, http.MethodGet, endpointLoginAcct+ls.State, acctHeaders, nil); errAcct == nil {
@@ -165,6 +193,7 @@ func main() {
 			"refresh_token": tok.RefreshToken,
 			"expires_in":    tok.ExpiresIn,
 			"domain":        tok.Domain,
+			"realm":         *realm,
 			"uid":           acct.UID,
 			"enterprise_id": acct.EnterpriseID,
 			"nickname":      acct.Nickname,
@@ -174,6 +203,6 @@ func main() {
 		os.Remove(stateFile)
 
 	default:
-		fatal("unknown subcommand %q (want url|poll)", os.Args[1])
+		fatal("unknown subcommand %q (want url|poll)", rest[0])
 	}
 }

--- a/cmd/signin/main.go
+++ b/cmd/signin/main.go
@@ -83,7 +83,8 @@ func main() {
 			r.status = "OK"
 			okN++
 		default:
-			// DailyCheckin 已签到返回 code!=0 错误
+			// DailyCheckin 已签到返回 code!=0 错误；国际版活动未开启回
+			// code=10001（"签到活动未开启或已过期"），同样走 ALREADY，不算失败
 			if isAlready(err.Error()) {
 				r.status = "ALREADY"
 				r.detail = short(err.Error())
@@ -94,7 +95,7 @@ func main() {
 				failN++
 			}
 		}
-		// 顺手查余额
+		// 顺手查余额：UserResource 已按域切路径（global 走 workbuddy.ai 相对路径版）
 		if remain, qerr := up.UserResource(a); qerr == nil {
 			r.remain, r.hasQuota = remain, true
 		}
@@ -115,13 +116,19 @@ func main() {
 	fmt.Printf("\ntotal=%d ok=%d already=%d fail=%d\n", len(rows), okN, alreadyN, failN)
 }
 
-// 已签判定：code 非 0 且含 "已签到"/"already"/"checkin" 等字样
+// 已签判定：code 非 0 且含 "已签到"/"already"/"checkin" 等字样；
+// 国际版签到活动未开启时回 code=10001（"签到活动未开启或已过期"），无分可领，
+// 同样不算失败，走 ALREADY 口径。
 func isAlready(msg string) bool {
 	s := strings.ToLower(msg)
 	return strings.Contains(s, "已签到") ||
 		strings.Contains(s, "already") ||
 		strings.Contains(s, "checkin") ||
-		strings.Contains(s, "code=400")
+		strings.Contains(s, "code=400") ||
+		strings.Contains(s, "10001") ||
+		strings.Contains(s, "未开启") ||
+		strings.Contains(s, "已过期") ||
+		strings.Contains(s, "inactive")
 }
 
 func trunc(s string, n int) string {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -41,6 +41,20 @@ func (a *Auth) NeedsRefresh(within time.Duration) bool {
 	return time.Now().Add(within).Unix() >= a.ExpiresAt
 }
 
+// IsGlobal 报告该账号是否属于国际版（workbuddy.ai 域）。
+// 判定规则：domain 以 .workbuddy.ai 结尾；空 domain 回落 CN（历史 CN 凭证无 domain 字段）。
+func (a *Auth) IsGlobal() bool {
+	return strings.HasSuffix(a.Domain, ".workbuddy.ai")
+}
+
+// Realm 返回账号所属域："global" 或 "cn"，供日志/调度区分。
+func (a *Auth) Realm() string {
+	if a.IsGlobal() {
+		return "global"
+	}
+	return "cn"
+}
+
 // Parse 兼容两种磁盘形态：
 //
 //	嵌套形 {"auth":{...},"account":{...}}  （插件 OAuth 输出）

--- a/internal/auth/realm_test.go
+++ b/internal/auth/realm_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import "testing"
+
+// IsGlobal 按 domain 后缀判域；空 domain 回落 CN（历史 CN 凭证无该字段）。
+func TestIsGlobal(t *testing.T) {
+	cases := []struct {
+		domain string
+		global bool
+	}{
+		{"copilot.tencent.com", false}, // CN 登录返回的 domain
+		{"", false},                    // 空 domain 回落 CN
+		{"www.codebuddy.cn", false},
+		{"abc.workbuddy.ai", true}, // 国际版
+		{"www.workbuddy.ai", true},
+		{"copilot.tencent.com.evil.workbuddy.ai", true}, // 后缀匹配
+	}
+	for _, c := range cases {
+		a := &Auth{Domain: c.domain}
+		if got := a.IsGlobal(); got != c.global {
+			t.Errorf("domain=%q: IsGlobal=%v, want %v", c.domain, got, c.global)
+		}
+		if want := map[bool]string{true: "global", false: "cn"}[c.global]; a.Realm() != want {
+			t.Errorf("domain=%q: Realm=%q, want %q", c.domain, a.Realm(), want)
+		}
+	}
+}

--- a/internal/pool/entry.go
+++ b/internal/pool/entry.go
@@ -29,6 +29,7 @@ func (k CoolKind) String() string {
 type Status struct {
 	UID             string    `json:"uid"`
 	Nickname        string    `json:"nickname,omitempty"`
+	Realm           string    `json:"realm,omitempty"` // cn|global（按 domain 后缀判）
 	Credits         int64     `json:"credits"`
 	Cooling         bool      `json:"cooling"`
 	CoolKind        string    `json:"cool_kind,omitempty"`

--- a/internal/pool/state.go
+++ b/internal/pool/state.go
@@ -245,6 +245,7 @@ func (p *Pool) statusOf(uid string, e *entry) Status {
 	st := Status{
 		UID:             uid,
 		Nickname:        e.a.Nickname,
+		Realm:           e.a.Realm(),
 		Credits:         e.credits,
 		Cooling:         now.Before(e.until) || now.Before(e.breakerUntil),
 		Reason:          e.reason,

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -166,6 +166,9 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 // RunCheckinNow 立即对所有账号执行签到 + 余额刷新 + 解冻。
 // 冷却中的账号也参与（签到就是为了解冻它们）；禁用的跳过。
+// 国际版（global）账号 DailyCheckin 路径已按域切换：国际版签到活动未开启
+// （active=false，调了回 10001 无分），UserResource 路径同样按域切换可用；
+// keepalive 保活对 global 照常执行。
 // 旅行已从签到剥离为独立排程（travel_hours），不再搭签到便车。
 func (s *Scheduler) RunCheckinNow() {
 	for _, st := range s.cfg.Pool.List() {
@@ -191,6 +194,7 @@ func (s *Scheduler) RunCheckinNow() {
 
 // RunActivityNow 立即对池内所有可用账号执行一次对话活跃上报。
 // 禁用账号跳过；无 AccessToken 的跳过；账号间限速 activityAccountDelay。
+// 国际版（global）账号同样上报：/v2/report 在 workbuddy.ai 上实测 code=0 OK。
 // 一条上报同时点亮 growth 连登 + 解锁 first_buddy 任务。
 // 上报成功后续跑 streak 自检（checkActivityStreak）：回读连登天数，发现
 // 「上报 200 但 streak 没涨」的静默丢弃（只读 oracle，不做重试）。

--- a/internal/scheduler/travel.go
+++ b/internal/scheduler/travel.go
@@ -37,6 +37,9 @@ func travelDay(t time.Time) string {
 
 // RunTravelNow 立即对池内所有可用账号执行一趟旅行巡检。
 // 禁用账号跳过；401/查询失败只跳过该账号本轮（不强刷 token，交 22:00 keepalive）；
+// 国际版（global）账号 DailyCheckin/UserResource 路径已按域切换，travel 接口
+// （/activity/growth/buddy/*）在 workbuddy.ai 上返回空 data（无猫/无奖励），
+// 调了无害，保留调用能力；是否启用由部署配置决定。
 // 账号间限速 travelAccountDelay。
 func (s *Scheduler) RunTravelNow() {
 	first := true

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -266,6 +267,11 @@ type Client struct {
 
 	ChatBaseCN    string
 	BillingBaseCN string
+
+	// 国际版（workbuddy.ai）base：账号 domain 以 .workbuddy.ai 结尾时启用。
+	// backend/billing/refresh 全切 https://www.workbuddy.ai，路径不变。
+	ChatBaseGlobal    string
+	BillingBaseGlobal string
 }
 
 // New 生产默认值。配置连接池减少 TLS 握手。
@@ -283,6 +289,8 @@ func New() *Client {
 		SanitizeFingerprints: true,
 		ChatBaseCN:           "https://copilot.tencent.com",
 		BillingBaseCN:        "https://www.codebuddy.cn",
+		ChatBaseGlobal:       "https://www.workbuddy.ai",
+		BillingBaseGlobal:    "https://www.workbuddy.ai",
 	}
 }
 
@@ -295,12 +303,68 @@ func (c *Client) chatHTTP() *http.Client {
 }
 
 func (c *Client) chatBase(a *auth.Auth) string {
+	if a != nil && a.IsGlobal() {
+		if c.ChatBaseGlobal != "" {
+			return c.ChatBaseGlobal
+		}
+	}
 	return c.ChatBaseCN
+}
+
+// chatURL 按账号域返回完整 chat 路径。
+// CN：{base}/v2/chat/completions；国际版：{base}/console/chat/completions
+// （实测国际版 v2 路径对国产模型通、对 gpt-5.4 等只在 console 路径通，
+// 为统一走 console；console 要求首条 system，由 prepareBodyFor 兜底补）。
+func (c *Client) chatURL(a *auth.Auth) string {
+	if a != nil && a.IsGlobal() {
+		return c.chatBase(a) + "/console/chat/completions"
+	}
+	return c.chatBase(a) + "/v2/chat/completions"
 }
 
 // prepareBody 组装出站请求体（脱敏开关由 Client.SanitizeFingerprints 控制）。
 func (c *Client) prepareBody(body []byte) []byte {
 	return PrepareBodyOptWithEfforts(body, c.SanitizeFingerprints, c.effortsSnapshot())
+}
+
+// prepareBodyFor 按账号域组装出站请求体：国际版 console 路径要求首条为
+// system（否则 11128），无 system 时补默认 system。
+func (c *Client) prepareBodyFor(a *auth.Auth, body []byte) []byte {
+	out := c.prepareBody(body)
+	if a != nil && a.IsGlobal() {
+		out = ensureConsoleSystem(out)
+	}
+	return out
+}
+
+// consoleSystemFallback console 路径补的默认 system（中性提示词，不携带指纹）。
+const consoleSystemFallback = "You are a helpful assistant."
+
+// ensureConsoleSystem 首条非 system 时头部插入默认 system；已有 system 则不动。
+func ensureConsoleSystem(src []byte) []byte {
+	if len(src) == 0 {
+		return src
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(src, &obj); err != nil {
+		return src
+	}
+	msgs, ok := obj["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		return src
+	}
+	first, ok := msgs[0].(map[string]any)
+	if ok {
+		if role, _ := first["role"].(string); role == "system" || role == "developer" {
+			return src
+		}
+	}
+	obj["messages"] = append([]any{map[string]any{"role": "system", "content": consoleSystemFallback}}, msgs...)
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return src
+	}
+	return out
 }
 
 // effortsSnapshot 返回 effort 能力缓存副本；nil 表示未知（透传不降级）。
@@ -318,15 +382,32 @@ func (c *Client) effortsSnapshot() map[string][]string {
 }
 
 func (c *Client) billingBase(a *auth.Auth) string {
+	if a != nil && a.IsGlobal() {
+		if c.BillingBaseGlobal != "" {
+			return c.BillingBaseGlobal
+		}
+	}
 	return c.BillingBaseCN
 }
 
 // billing 域端点路径（billingBase + path）。balance/checkin 与 report（report.go）同域，
 // 统一走 billingJSON 发请求。
+// 国际版注意：billingBaseGlobal(www.workbuddy.ai) 不认 /v2 前缀，相对路径版
+// /billing/meter/* 经网关代理到计费服务；CN 版走 codebuddy.cn /v2 前缀版。
 const (
-	billingMeterPath = "/v2/billing/meter/get-user-resource"
-	dailyCheckinPath = "/v2/billing/meter/daily-checkin"
+	billingMeterPath       = "/v2/billing/meter/get-user-resource"
+	dailyCheckinPath       = "/v2/billing/meter/daily-checkin"
+	billingMeterPathGlobal = "/billing/meter/get-user-resource"
+	dailyCheckinPathGlobal = "/billing/meter/daily-checkin"
 )
+
+// billingPathFor 按账号域选 billing 路径。
+func billingPathFor(a *auth.Auth, cn, global string) string {
+	if a != nil && a.IsGlobal() {
+		return global
+	}
+	return cn
+}
 
 // doJSON 发请求并解信封；HTTP 非 2xx 或业务 code != 0 时返回带 body 片段的 *Error。
 func (c *Client) doJSON(req *http.Request) (json.RawMessage, error) {
@@ -399,8 +480,8 @@ func (c *Client) RefreshToken(a *auth.Auth) error {
 // 非 2xx 时 rc 为 nil、body 为上游响应体（供调用方 Classify(status, string(body))）、err 为 nil；
 // 只有传输层失败才返回 err。
 func (c *Client) ChatStream(a *auth.Auth, body []byte) (rc io.ReadCloser, status int, respBody []byte, err error) {
-	url := c.chatBase(a) + "/v2/chat/completions"
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(c.prepareBody(body)))
+	url := c.chatURL(a)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(c.prepareBodyFor(a, body)))
 	if err != nil {
 		return nil, 0, nil, err
 	}
@@ -438,8 +519,15 @@ type ModelInfo struct {
 }
 
 // FetchModels 调上游动态模型接口。
+// CN：GET {chatBase}/console/enterprises/personal/models（cli agent 白名单）。
+// 国际版（global）：该路径 500，改走"探测"模式——对候选模型表逐个用
+// {chatBase}/console/chat/completions 做最小流式探测，通的即为可用。
+// 探测结果缓存由 handler 层复用（与 CN 路径同 TTL/负缓存语义）。
 // 字段名与上游实际返回对齐：maxInputTokens（非 contextWindow）、maxOutputTokens（非 maxTokens）。
 func (c *Client) FetchModels(a *auth.Auth) ([]ModelInfo, error) {
+	if a != nil && a.IsGlobal() {
+		return c.fetchGlobalModels(a)
+	}
 	url := c.chatBase(a) + "/console/enterprises/personal/models"
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
@@ -540,6 +628,128 @@ func (c *Client) FetchModels(a *auth.Auth) ([]ModelInfo, error) {
 	return out, nil
 }
 
+// globalProbeModels 国际版候选模型表：网页 /app bundle 的 modelOptions 去重
+// （2026-09-12 提取），探测只保留 console 路径实际可用的。
+// 大小写敏感（GPT-5 大写不认）；console 要求首条 system。
+var globalProbeModels = []string{
+	// OpenAI 系
+	"gpt-5.4", "gpt-5.3-codex", "gpt-5", "gpt-5-mini", "gpt-5-nano",
+	"gpt-4.1", "gpt-4o", "gpt-4o-mini", "o1", "o3", "o3-mini",
+	// Gemini 系（探测按 code 判定：11102=无此模型跳过，通/11133/11128=可用保留）
+	"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+	"gemini-3-flash-preview", "gemini-3.1-pro-preview", "gemini-3.1-flash",
+	"gemini-3.1-flash-lite", "gemini-3.5-flash",
+	// Kimi 系
+	"kimi-k3", "kimi-k2-0905-preview", "kimi-k2-0711-preview",
+	"kimi-k2-thinking", "kimi-k2-thinking-turbo", "kimi-k2-turbo-preview",
+	"kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "kimi-k2.7-code-highspeed",
+	// GLM 系
+	"glm-5", "glm-5-turbo", "glm-5.1", "glm-5.2",
+	// MiniMax 系
+	"minimax-m2.5", "minimax-m2.7", "minimax-m3",
+	// DeepSeek 系
+	"deepseek-v4-flash", "deepseek-v4-flash-202605", "deepseek-v4.1-flash",
+	"deepseek-v4-pro", "deepseek-v4-pro-202606",
+	// Hunyuan 系 + auto
+	"hunyuan-2.0-thinking", "hunyuan-2.0-instruct", "hunyuan-turbos", "hunyuan-t1",
+	"hy3", "hy4-preview", "hy4-preview-x",
+	"tc-code-latest", "auto",
+}
+
+// fetchGlobalModels 国际版模型探测：6 并发最小流式探测，通的即为可用。
+// 探测请求 max_tokens=32、首条 system（gpt-5.4 拒绝 max_tokens=1，会 11133）；
+// 11102/11101（service info not found）= 该模型对此账号不可用，跳过；
+// 11133/11128（参数/格式问题）说明模型名已通过服务端解析，视为可用；
+// 其他错误（网络/401/429）为账号级问题，记 firstFatal（有可用模型时忽略，
+// 全灭时返回）。探测不罚账号：只读 Classify，不调 pool。
+func (c *Client) fetchGlobalModels(a *auth.Auth) ([]ModelInfo, error) {
+	type res struct {
+		idx int
+		id  string
+		ok  bool
+		err error
+	}
+	ch := make(chan res, len(globalProbeModels))
+	sem := make(chan struct{}, 6) // 最多 6 并发探测
+	for i, id := range globalProbeModels {
+		go func(idx int, mid string) {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			ok, err := c.probeGlobalModel(a, mid)
+			ch <- res{idx, mid, ok, err}
+		}(i, id)
+	}
+	tmp := make([]res, 0, len(globalProbeModels))
+	var firstFatal error
+	for range globalProbeModels {
+		r := <-ch
+		if r.err != nil && firstFatal == nil {
+			firstFatal = r.err
+		}
+		tmp = append(tmp, r)
+	}
+	// 按候选表顺序还原（/v1/models 输出稳定）。
+	sort.Slice(tmp, func(i, j int) bool { return tmp[i].idx < tmp[j].idx })
+	var out []ModelInfo
+	for _, r := range tmp {
+		if r.err == nil && r.ok {
+			out = append(out, ModelInfo{ID: r.id, Name: r.id, ContextWindow: 131072})
+		}
+	}
+	if len(out) == 0 && firstFatal != nil {
+		return nil, firstFatal
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("global models probe: no model available")
+	}
+	return out, nil
+}
+
+// probeGlobalModel 探测单个模型在国际版 console 路径是否可用。
+// 返回 (可用, 致命错误)。模型级 11102/11101 → (false, nil)；
+// 11133/11128 → (true, nil)；账号级问题（网络/401/429）→ (false, err)。
+func (c *Client) probeGlobalModel(a *auth.Auth, model string) (bool, error) {
+	body, _ := json.Marshal(map[string]any{
+		"model": model,
+		"messages": []map[string]string{
+			{"role": "system", "content": "You are a helpful assistant."},
+			{"role": "user", "content": "hi"},
+		},
+		"stream":     true,
+		"max_tokens": 32,
+	})
+	url := c.chatBase(a) + "/console/chat/completions"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return false, err
+	}
+	c.ChatHeaders(req, a)
+	resp, err := c.chatHTTP().Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 400 {
+		s := string(raw)
+		// 模型名不存在 → 跳过此模型。
+		if strings.Contains(s, `"code":11102`) || strings.Contains(s, `"code":11101`) {
+			return false, nil
+		}
+		// 模型名已解析（参数/格式问题）→ 视为可用。
+		if strings.Contains(s, `"code":11133`) || strings.Contains(s, `"code":11128`) {
+			return true, nil
+		}
+		kind := Classify(resp.StatusCode, s)
+		// 模型级不可用：跳过此模型。
+		if kind == ErrClient || kind == ErrBadParams {
+			return false, nil
+		}
+		return false, fmt.Errorf("global probe %s: upstream %d %s", model, resp.StatusCode, truncate(s, 120))
+	}
+	return true, nil
+}
+
 // UserResource 查询账号当前可花费积分余额（所有套餐 CycleCapacity 聚合，负值钳 0）。
 func (c *Client) UserResource(a *auth.Auth) (remain int64, err error) {
 	now := time.Now()
@@ -551,7 +761,7 @@ func (c *Client) UserResource(a *auth.Auth) (remain int64, err error) {
 		"PackageEndTimeRangeBegin": now.Format("2006-01-02 15:04:05"),
 		"PackageEndTimeRangeEnd":   now.Add(365 * 101 * 24 * time.Hour).Format("2006-01-02 15:04:05"),
 	}
-	data, err := c.billingJSON(a, http.MethodPost, billingMeterPath, body)
+	data, err := c.billingJSON(a, http.MethodPost, billingPathFor(a, billingMeterPath, billingMeterPathGlobal), body)
 	if err != nil {
 		return 0, err
 	}
@@ -592,8 +802,10 @@ func (c *Client) UserResource(a *auth.Auth) (remain int64, err error) {
 }
 
 // DailyCheckin 执行每日签到。已签到（业务 code 非 0）也返回错误，调用方按 msg 区分。
+// 国际版：checkin-activity-status 显示 active=false（签到活动未开启），调也拿不到
+// 分；路径已按域切换，保留调用能力，是否启用由 scheduler/signin 的 IsGlobal 门控决定。
 func (c *Client) DailyCheckin(a *auth.Auth) error {
-	_, err := c.billingJSON(a, http.MethodPost, dailyCheckinPath, map[string]any{})
+	_, err := c.billingJSON(a, http.MethodPost, billingPathFor(a, dailyCheckinPath, dailyCheckinPathGlobal), map[string]any{})
 	return err
 }
 

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -402,9 +402,35 @@ func TestBasesAlwaysCN(t *testing.T) {
 	if c.chatBase(cn) != "https://chat.example" || c.billingBase(cn) != "https://billing.example" {
 		t.Error("cn bases wrong")
 	}
-	// 恒 CN：domain 不同不改变上游 host。
+	// 非 workbuddy.ai 后缀的 domain 不改变上游 host。
 	if c.chatBase(other) != c.chatBase(cn) || c.billingBase(other) != c.billingBase(cn) {
 		t.Error("bases must be CN regardless of domain")
+	}
+}
+
+// TestBasesGlobalByDomain 国际版账号（domain 以 .workbuddy.ai 结尾）切到
+// www.workbuddy.ai；New() 默认值即此（空 Client 字段回落 CN 不影响）。
+func TestBasesGlobalByDomain(t *testing.T) {
+	c := New()
+	cn := &auth.Auth{Domain: "copilot.tencent.com"}
+	global := &auth.Auth{Domain: "abc.workbuddy.ai"}
+	if c.chatBase(global) != "https://www.workbuddy.ai" {
+		t.Errorf("global chatBase=%q", c.chatBase(global))
+	}
+	if c.billingBase(global) != "https://www.workbuddy.ai" {
+		t.Errorf("global billingBase=%q", c.billingBase(global))
+	}
+	if c.chatBase(cn) != "https://copilot.tencent.com" {
+		t.Errorf("cn chatBase=%q", c.chatBase(cn))
+	}
+	if c.billingBase(cn) != "https://www.codebuddy.cn" {
+		t.Errorf("cn billingBase=%q", c.billingBase(cn))
+	}
+	if originRefererFor(global) != "https://www.workbuddy.ai" {
+		t.Errorf("global origin=%q", originRefererFor(global))
+	}
+	if originRefererFor(cn) != "https://www.codebuddy.cn" {
+		t.Errorf("cn origin=%q", originRefererFor(cn))
 	}
 }
 

--- a/internal/upstream/global_test.go
+++ b/internal/upstream/global_test.go
@@ -1,0 +1,60 @@
+package upstream
+
+import (
+	"encoding/json"
+	"testing"
+
+	"workbuddy2api/internal/auth"
+)
+
+// console 路径要求首条 system：无 system 时补，有则不动。
+func TestEnsureConsoleSystem(t *testing.T) {
+	// 无 system → 补
+	src := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}]}`)
+	out := ensureConsoleSystem(src)
+	var obj map[string]any
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatal(err)
+	}
+	msgs := obj["messages"].([]any)
+	if len(msgs) != 2 {
+		t.Fatalf("want 2 msgs, got %d", len(msgs))
+	}
+	if msgs[0].(map[string]any)["role"] != "system" {
+		t.Errorf("first msg role=%v, want system", msgs[0].(map[string]any)["role"])
+	}
+	// 已有 system → 不动
+	src2 := []byte(`{"model":"x","messages":[{"role":"system","content":"s"},{"role":"user","content":"hi"}]}`)
+	if got := string(ensureConsoleSystem(src2)); got != string(src2) {
+		t.Errorf("system present: body changed: %s", got)
+	}
+}
+
+// chatURL 按域切路径。
+func TestChatURL(t *testing.T) {
+	c := New()
+	if got := c.chatURL(&auth.Auth{Domain: "copilot.tencent.com"}); got != "https://copilot.tencent.com/v2/chat/completions" {
+		t.Errorf("cn url=%q", got)
+	}
+	if got := c.chatURL(&auth.Auth{Domain: "x.workbuddy.ai"}); got != "https://www.workbuddy.ai/console/chat/completions" {
+		t.Errorf("global url=%q", got)
+	}
+}
+
+// prepareBodyFor：global 无 system 补 system，CN 不动。
+func TestPrepareBodyFor(t *testing.T) {
+	c := New()
+	src := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hi"}],"stream":false}`)
+	g := c.prepareBodyFor(&auth.Auth{Domain: "x.workbuddy.ai"}, src)
+	var gobj map[string]any
+	_ = json.Unmarshal(g, &gobj)
+	if gobj["messages"].([]any)[0].(map[string]any)["role"] != "system" {
+		t.Error("global: system not prepended")
+	}
+	cn := c.prepareBodyFor(&auth.Auth{Domain: "copilot.tencent.com"}, src)
+	var cobj map[string]any
+	_ = json.Unmarshal(cn, &cobj)
+	if cobj["messages"].([]any)[0].(map[string]any)["role"] != "user" {
+		t.Error("cn: messages changed unexpectedly")
+	}
+}

--- a/internal/upstream/headers.go
+++ b/internal/upstream/headers.go
@@ -11,9 +11,14 @@ import (
 const (
 	clientUA        = "CLI/2.63.2 CodeBuddy/2.63.2"
 	originRefererCN = "https://www.codebuddy.cn"
+	// originRefererGlobal 国际版 Origin/Referer（与 backend 同域）。
+	originRefererGlobal = "https://www.workbuddy.ai"
 )
 
 func originRefererFor(a *auth.Auth) string {
+	if a != nil && a.IsGlobal() {
+		return originRefererGlobal
+	}
 	return originRefererCN
 }
 

--- a/login.sh
+++ b/login.sh
@@ -1,19 +1,27 @@
 #!/usr/bin/env bash
-# login.sh — WorkBuddy CN OAuth 登录 → 落盘 auth 文件
+# login.sh — WorkBuddy CN/国际版 OAuth 登录 → 落盘 auth 文件
 #
 # 用法:
-#   ./login.sh
+#   ./login.sh [--realm=cn|global]   # 默认 cn；国际版用 --realm=global
 #
 # 流程:
-#   1. POST /v2/plugin/auth/state 拿授权 URL（无 PKCE，state 由服务端签发）
+#   1. POST {base}/v2/plugin/auth/state 拿授权 URL（无 PKCE，state 由服务端签发）
 #   2. 你在浏览器打开 URL 完成登录
-#   3. 回到这里按 y → poll 拿 token+uid+nickname → 签到 → 落盘 auths/workbuddy-<uid>.json
+#   3. 回到这里按 y → poll 拿 token+uid+nickname → 签到（仅 CN，国际版跳过）→ 落盘 auths/workbuddy-<uid>.json
 #   4. 重启 workbuddy2api 容器加载新账号
 set -euo pipefail
 
 cd "$(dirname "$0")"
 AUTH_DIR="./auths"
 CONTAINER="workbuddy2api"
+# realm 参数透传给 login 二进制（默认 cn）
+REALM_ARGS=()
+REALM="cn"
+for arg in "$@"; do
+  case "$arg" in
+    --realm=*) REALM="${arg#--realm=}"; REALM_ARGS=("$arg");;
+  esac
+done
 
 mkdir -p "$AUTH_DIR"
 
@@ -28,7 +36,7 @@ echo "  WorkBuddy OAuth 登录"
 echo "============================================================"
 echo ""
 
-AUTH_URL=$("$LOGIN_BIN" url)
+AUTH_URL=$("$LOGIN_BIN" "${REALM_ARGS[@]}" url)
 
 echo "请在浏览器中打开以下链接完成登录："
 echo ""
@@ -51,7 +59,7 @@ fi
 echo ""
 echo "正在获取 token..."
 
-RESULT=$("$LOGIN_BIN" poll) || {
+RESULT=$("$LOGIN_BIN" "${REALM_ARGS[@]}" poll) || {
     echo ""
     echo "获取 token 失败。可能原因："
     echo "  - 登录还没完成就按了 y（重新运行 ./login.sh 再试）"
@@ -74,7 +82,11 @@ fi
 
 EXPIRES_AT=$(( $(date +%s) + EXPIRES_IN ))
 
-# ─── 签到（CN：POST codebuddy.cn/v2/billing/meter/daily-checkin，幂等不阻塞）───
+# ─── 签到（仅 CN：POST codebuddy.cn/v2/billing/meter/daily-checkin，幂等不阻塞；
+#     国际版无此体系，跳过）───
+if [[ "$REALM" == "global" ]]; then
+  echo "签到: 跳过（国际版无 CN 签到体系）"
+else
 python3 - <<PYEOF
 import json, urllib.request, urllib.error
 
@@ -107,6 +119,7 @@ except urllib.error.HTTPError as e:
 except Exception as e:
     print(f"签到: {e}")
 PYEOF
+fi
 
 # ─── 落盘 auth 文件（与 internal/auth 读取格式一致）─────────────────
 AUTH_FILE="$AUTH_DIR/workbuddy-${USER_ID}.json"


### PR DESCRIPTION
## Summary
- upstream Chat/Billing base 按账号域切换；chat 路径 global 走 `/console/chat/completions` + 首条 system 兜底；billing 路径 global 走网关代理相对路径 `/billing/meter/*`
- FetchModels global 改 6 并发最小流式探测（48 候选，实测 14 可用）
- pool /status 透出 realm=cn|global
- scheduler/signin/credit 路径按域切换；国际版签到活动未开启（10001）走 ALREADY 口径；report 上报 global 照常
- CN 默认行为零变化（空 domain / 空 Global base 回落 CN）

## 实测
- workbuddy2api-global(7864)：gpt-5.4 出字通；/v1/models 14 个；credit remain=350；signin ALREADY
- go vet + go test ./... 全过；go build OK

## Stacks on
- #44（OAuth 双 realm）：本 PR 基于 PR1 之后，建议按序合并（本分支已含 PR1 commit，合并时以 master 最新为准）