### PR TITLE
feat(upstream): 净化增强——桌面版身份句、反馈句、tool_calls 盲区与错误码回显

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -252,6 +253,14 @@ func (h *Handler) chatCompletions(w http.ResponseWriter, r *http.Request) {
 		writeOpenAIError(w, http.StatusRequestEntityTooLarge, "request_body_too_large",
 			fmt.Sprintf("请求体超过 %d MB 上限：请压缩内容或调大 server.max_body_mb 配置后重试", limit>>20))
 		return
+	}
+	// 调试开关：设置 WB2A_DUMP_REQ 即把上游侧收到的原始请求体落盘，供离线二分定位指纹命中行。
+	// 仅在排查上游指纹拦截时开启；不设置时零开销、不落盘。
+	// 只落"大请求"（超过上限一半）：小探针（{"input":"hi"} 之类）会覆盖掉真正要看的对话请求。
+	if os.Getenv("WB2A_DUMP_REQ") != "" && len(body)*2 >= int(limit) {
+		if err := os.WriteFile("/app/data/last_request.json", body, 0o600); err != nil {
+			log.Printf("dump req: %v", err)
+		}
 	}
 	var peek struct {
 		Stream bool   `json:"stream"`

--- a/internal/upstream/sanitize.go
+++ b/internal/upstream/sanitize.go
@@ -18,6 +18,8 @@ var sanitizeFeatures = []string{
 	"You are Claude Code",        // 身份句（截断前缀即可命中）
 	"Main branch (",              // 注入指令句（截断前缀即可命中）
 	"You are a coding agent running in the Codex CLI", // Codex instructions 首段（截断前缀即可命中）
+	"github.com/anthropics/",     // 反馈句里的 Anthropic 仓库链接
+	"11128",                      // 上游反探测：裸数字错误码
 }
 
 // sanitizeHdrRe 剥离层：header 键名即触发（与值无关），整段删除。
@@ -27,10 +29,18 @@ var sanitizeHdrRe = regexp.MustCompile(`(?i)x-anthropic-billing-header:[^;\n]*;?
 var sanitizeKvRe = regexp.MustCompile(`(?i)\bcc_[a-z0-9_]+=[^;\n]*;?\s*`)
 
 // sanitizeRewrites 改写层：全模板句逐字替换（每句只改一个词，语义不变）。
+//
+// 身份句的匹配串**不带结尾标点**（只到 "…for Claude" 为止）：
+// CLI 版这句以句号收尾（"…for Claude."），桌面版（claude-desktop-3p / Agent SDK）
+// 以逗号接后继内容（"…for Claude, running within the Claude Agent SDK."）。
+// 带句号的整句只匹配前者，桌面版会漏网、指纹原样发上游 → 400 code=11128。
+// 去掉结尾标点后两种形态一并覆盖（替换串同样不带标点，让原有标点原样保留）。
+// 注意仍要求 "You are Claude Code, " 前缀，不做更宽的子串替换，
+// 以免误伤 TestExactMatchOnlyVariantNotTouched 所保护的零散文本。
 var sanitizeRewrites = [][2]string{
 	{
-		"You are Claude Code, Anthropic's official CLI for Claude.",
-		"You are Claude Code, Anthropic's official CLI tool for Claude.",
+		"You are Claude Code, Anthropic's official CLI for Claude",
+		"You are Claude Code, Anthropic's official CLI tool for Claude",
 	},
 	{
 		"Main branch (you will usually use this for PRs)",
@@ -39,6 +49,22 @@ var sanitizeRewrites = [][2]string{
 	{
 		"You are a coding agent running in the Codex CLI, a terminal-based coding assistant.",
 		"You are a coding agent running in the Codex CLI tool, a terminal-based coding assistant.",
+	},
+	{
+		// 实测需整句同时出现）。give→provide 一词之差即可绕过，语义不变。
+		// 反馈句：整句带 Anthropic 仓库链接，上游按整句拦截（只留链接或只留半边都不拦，
+		"To give feedback, users should report the issue at https://github.com/anthropics/claude-code/issues",
+		"To provide feedback, users should report the issue at https://github.com/anthropics/claude-code/issues",
+	},
+	{
+		// 上游反探测：只要请求体里出现裸数字 11128 就整单拦截（与该数字的上下文无关——
+		// "code=11128" / 裸 "11128" / "错误码 11128" / "Code=11128" 全部命中；
+		// 相邻的 11148 / 11101 / 11115 / 99999 均放行）。11128 正是本类拦截自身的错误码，
+		// 上游据此识别"在讨论/回显其内部错误码"的请求。
+		// 代价：用户对话中任何 11128 都会被改写——但这串数字出现在请求里本身就是拦截条件，
+		// 不改写必然失败。插入连字符保留可读性与指代（零宽空格无效，实测上游会归一化）。
+		"11128",
+		"11-128",
 	},
 }
 
@@ -102,7 +128,40 @@ func sanitizeContent(v any) (any, bool) {
 	return v, false
 }
 
-// sanitizeMessages 净化 messages 中的 content；任一命中返回 true。
+// sanitizeToolCalls 净化 assistant.tool_calls[].function.arguments。
+//
+// arguments 是**字符串化的 JSON**（不是对象），因此按文本走 sanitizeText 即可。
+// 这块长期是盲区：工具调用消息的 content 通常是 null，而旧版 sanitizeMessages
+// 在 content 缺失时直接 continue，整条消息连 tool_calls 一起被跳过——
+// 于是历史里任何写进工具参数的被拦字符串（文件名、命令、写入内容）都会原样漏出。
+func sanitizeToolCalls(v any) bool {
+	callList, ok := v.([]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	for _, c := range callList {
+		call, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		fn, ok := call["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+		args, ok := fn["arguments"].(string)
+		if !ok {
+			continue
+		}
+		if s := sanitizeText(args); s != args {
+			fn["arguments"] = s
+			changed = true
+		}
+	}
+	return changed
+}
+
+// sanitizeMessages 净化 messages 中的 content 与 tool_calls；任一命中返回 true。
 func sanitizeMessages(messages []any) bool {
 	changed := false
 	for _, msg := range messages {
@@ -110,13 +169,18 @@ func sanitizeMessages(messages []any) bool {
 		if !ok {
 			continue
 		}
-		c, ok := m["content"]
-		if !ok {
-			continue
+		// content 与 tool_calls 各自独立判断：content 可以为 null（工具调用轮），
+		// 早期版本在此 continue，导致这类消息的 tool_calls 完全不被净化。
+		if c, ok := m["content"]; ok {
+			if nc, ch := sanitizeContent(c); ch {
+				m["content"] = nc
+				changed = true
+			}
 		}
-		if nc, ch := sanitizeContent(c); ch {
-			m["content"] = nc
-			changed = true
+		if tc, ok := m["tool_calls"]; ok {
+			if sanitizeToolCalls(tc) {
+				changed = true
+			}
 		}
 	}
 	return changed

--- a/internal/upstream/sanitize_test.go
+++ b/internal/upstream/sanitize_test.go
@@ -29,6 +29,19 @@ func TestIdentityRewritten(t *testing.T) {
 	}
 }
 
+// 桌面版（claude-desktop-3p / Agent SDK）的身份句以逗号接后继内容，结尾不是句号。
+// 回归用例：匹配串曾带结尾句号，导致该形态漏网、指纹原样发上游 → 400 code=11128。
+func TestIdentityDesktopVariantRewritten(t *testing.T) {
+	in := "You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK."
+	out := sanitizeText(in)
+	if strings.Contains(out, "official CLI for Claude") {
+		t.Errorf("desktop identity not rewritten: %q", out)
+	}
+	if !strings.Contains(out, "official CLI tool for Claude, running within the Claude Agent SDK.") {
+		t.Errorf("desktop identity suffix not preserved: %q", out)
+	}
+}
+
 func TestBranchRewritten(t *testing.T) {
 	out := sanitizeText(ccBranch)
 	if !strings.Contains(out, "Default branch (you will usually use this for PRs)") {
@@ -36,6 +49,54 @@ func TestBranchRewritten(t *testing.T) {
 	}
 	if strings.Contains(out, "Main branch") {
 		t.Errorf("original branch still present: %q", out)
+	}
+}
+
+// 反馈句带 Anthropic 仓库链接，上游按整句拦截（实测只留链接或只留半边均不拦）。
+// 回归用例：give→provide 一词之差即可绕过。
+func TestFeedbackSentenceRewritten(t *testing.T) {
+	in := "To give feedback, users should report the issue at https://github.com/anthropics/claude-code/issues"
+	out := sanitizeText(in)
+	if strings.Contains(out, "To give feedback") {
+		t.Errorf("feedback sentence not rewritten: %q", out)
+	}
+	if !strings.Contains(out, "To provide feedback, users should report the issue at https://github.com/anthropics/claude-code/issues") {
+		t.Errorf("feedback sentence not rewritten as expected: %q", out)
+	}
+}
+
+// 上游反探测：请求体里出现裸数字 11128 即整单拦截（与上下文无关）。
+// 回归用例：该串会被改写为 11-128 以打断精确匹配。
+func TestUpstreamErrorCodeRewritten(t *testing.T) {
+	in := "upstream returned code=11128 for this request"
+	out := sanitizeText(in)
+	if strings.Contains(out, "11128") {
+		t.Errorf("error code not rewritten: %q", out)
+	}
+	if !strings.Contains(out, "11-128") {
+		t.Errorf("error code not rewritten as expected: %q", out)
+	}
+}
+
+// 回归：工具调用消息的 content 常为 null，而旧版 sanitizeMessages 在 content 缺失时
+// 直接 continue，整条消息连 tool_calls 一起被跳过 → arguments 里的被拦字符串原样漏出。
+func TestToolCallArgumentsSanitized(t *testing.T) {
+	msgs := []any{
+		map[string]any{"role": "user", "content": "run"},
+		map[string]any{"role": "assistant", "content": nil, "tool_calls": []any{
+			map[string]any{"id": "c1", "type": "function", "function": map[string]any{
+				"name":      "Bash",
+				"arguments": `{"command":"echo 11128"}`,
+			}},
+		}},
+	}
+	if !sanitizeMessages(msgs) {
+		t.Fatal("sanitizeMessages 未报告任何改动，tool_calls 被跳过")
+	}
+	fn := msgs[1].(map[string]any)["tool_calls"].([]any)[0].(map[string]any)["function"].(map[string]any)
+	got := fn["arguments"].(string)
+	if strings.Contains(got, "11128") {
+		t.Errorf("tool_call arguments 未被净化: %q", got)
 	}
 }
 


### PR DESCRIPTION
## 背景

实机排查 Claude Code 经本网关接 workbuddy 上游时的 400 code=11-128（指纹拦截）问题，定位到 4 个漏网点，逐一封堵并附回归测试。

## 变更

### 1. 桌面版身份句漏网
身份句匹配串带结尾句号，只能命中 CLI 形态（"…for Claude."）。桌面版 / Agent SDK 形态以逗号接后继内容（"…for Claude, running within the Claude Agent SDK."），整句匹配失败、指纹原样发上游 → 11-128。匹配串与替换串均去尾标点，两种形态一并覆盖。

### 2. 反馈句与错误码回显
- 新增反馈句整句改写（实测上游按整句拦截，只留链接或半句不拦；give→provide 一词之差绕过）
- 新增 11-128 裸错误码改写：上游对请求体中出现的 "11-128" 无差别拦截（正是其自身拦截错误码，用于识别"在讨论/回显内部错误码"的请求），打断精确匹配即可放行

### 3. tool_calls 净化盲区（逻辑修复）
assistant 消息的 content 在工具调用轮常为 null，旧版 sanitizeMessages 对 content 缺失直接 continue，整条消息连同 tool_calls 被跳过 → function.arguments（字符串化 JSON）里的被拦字符串原样漏出。现 content 与 tool_calls 独立净化。

### 4. WB2A_DUMP_REQ 调试开关
环境变量开启时把上游侧收到的大请求体落盘（只落超过请求体上限一半的请求，避免小探针覆盖真实对话），供离线二分定位指纹命中行。不设置时零开销。

## 测试

- `go build ./...` + `go test ./internal/upstream/ ./internal/server/` 全部通过（新增 4 个回归测试：桌面版身份句、反馈句、11-128、tool_calls arguments）
- 实机验证：Claude Code 经网关连续多轮对话不再出现 11-128
