### PR TITLE
feat(checkin): 新增手动签到接口与启动补签，修复"已签到"被误读为失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ curl -s http://localhost:7863/v1/models \
 curl -s http://localhost:7863/status \
   -H "Authorization: Bearer your-api-key"
 
+# 手动签到（错过整点签到时补签；返回逐账号结果）
+curl -s -X POST http://localhost:7863/checkin \
+  -H "Authorization: Bearer your-api-key"
+
 # 流式聊天
 curl -sN http://localhost:7863/v1/chat/completions \
   -H "Authorization: Bearer your-api-key" \
@@ -141,7 +145,7 @@ curl -s http://localhost:7863/v1/chat/completions \
   "auth_dir": "./auths",
   "state_file": "./data/state.json",
   "cooldown": { "soft_rate": "60s" },
-  "schedule": { "checkin_hours": [9, 21], "keepalive_hours": [22] },
+  "schedule": { "checkin_hours": [9, 21], "keepalive_hours": [22], "checkin_on_start": true },
   "upstream": {
     "timeout_seconds": 120,
     "header_timeout_seconds": 120,
@@ -172,6 +176,7 @@ curl -s http://localhost:7863/v1/chat/completions \
 | `cooldown.soft_rate` | `60s` | 429/404 软冷却时长 |
 | `schedule.checkin_hours` | `[9, 21]` | 每日本地时区整点签到 + 余额查询 |
 | `schedule.keepalive_hours` | `[22]` | 每日本地时区整点刷新 token 保活 |
+| `schedule.checkin_on_start` | `true` | 服务/容器启动时补签一次（停机错过整点签到的补偿） |
 | `upstream.timeout_seconds` | `120` | 短 RPC（刷新/签到/余额/模型）总时长上限 |
 | `upstream.header_timeout_seconds` | 回落 `timeout_seconds` | 聊天首字节前（响应头）上限 |
 | `upstream.idle_timeout_seconds` | `300` | 聊天流中空闲上限（活跃续命，静默断流） |
@@ -258,10 +263,15 @@ curl -s http://localhost:7863/v1/chat/completions \
 
 ### 定时任务
 
-| 任务 | 时刻（本地时区） | 行为 |
+| 任务 | 触发 | 行为 |
 |---|---|---|
 | 签到 | `checkin_hours` 默认 `[9, 21]` 整点 | 签到 + 余额查询；余额恢复则解冻冷却账号 |
 | 保活 | `keepalive_hours` 默认 `[22]` 整点 | 全账号刷新 token；session 失效自动禁用 |
+| 启动补签 | 服务/容器启动时（`checkin_on_start`） | 停机错过整点签到时立即补一次；重复签到由上游判为已签到，安全幂等 |
+
+主机/容器整夜关机导致错过 `checkin_hours` 时，重启后由启动补签自动补齐；
+也可随时用 `POST /checkin` 手动触发（见下方 API 端点）。签到前会按需刷新 token，
+所以长时间停机后过期的 access token 不会让补签空跑。
 
 容器时区由 `TZ` 控制（compose 默认 `Asia/Shanghai`）。
 
@@ -272,9 +282,25 @@ curl -s http://localhost:7863/v1/chat/completions \
 | `POST /v1/chat/completions` | Bearer（`api_key` 非空时） | OpenAI 兼容补全；流式/非流式；请求体上限 8 MiB |
 | `GET /v1/models` | Bearer（`api_key` 非空时） | 模型列表（动态拉取，缓存 1h；失败回落静态表 + 5min 负缓存） |
 | `GET /status` | Bearer（`api_key` 非空时） | 账号状态汇总 + 每账号详情（积分/冷却/熔断/在途/粘性） |
+| `POST /checkin` | Bearer（`api_key` 非空时） | 手动触发全量签到（补签入口）；返回逐账号结果；已有签到在跑返回 409 |
 | `GET /healthz` | 无 | 健康检查：有 healthy 且未占满账号返回 200，否则 503 |
 
 > 鉴权规则：仅当 `api_key` 非空才校验 `Authorization: Bearer <api_key>`；**`api_key` 为空时上述端点直接放行**；`/healthz` 恒无鉴权。
+
+`POST /checkin` 响应示例（`account.status`：`ok` 签到成功 / `already` 今天已签到 / `fail` 失败 / `skipped` 禁用或无凭证）：
+
+```json
+{
+  "total": 2, "ok": 1, "already": 1, "failed": 0, "skipped": 0,
+  "accounts": [
+    { "uid": "u1", "nickname": "nick", "status": "ok", "credits": 1200 },
+    { "uid": "u2", "status": "already", "credits": 800 }
+  ]
+}
+```
+
+> `already` 是幂等成功（当天已完成签到），**不带** `detail`；仅 `fail`/`skipped` 会带原因。
+> 终端里想直接看表格结果：`./checkin.sh`。
 
 ### 流式行为细节
 
@@ -345,7 +371,7 @@ curl -s http://localhost:7863/v1/chat/completions \
 
 - **无预编译 release**：仓库无 Release / tag，产物 = 源码自构建
 - 构建命令：`CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o wb2api ./cmd/server`（Dockerfile 多阶段：`golang:1.23-alpine` 构建 → `alpine:3.20` 运行）
-- 登录/签到/积分工具：`./login.sh` / `./signin.sh` / `./credit.sh`（缺失时自动编译对应 `cmd/*`）
+- 登录/签到/积分工具：`./login.sh` / `./signin.sh` / `./checkin.sh` / `./credit.sh`（缺失时自动编译对应 `cmd/*`）
 - **无产物校验和**：`go.sum` 仅约束 Go 模块依赖；Docker 镜像由本地 `docker compose build` 生成，未引用第三方镜像
 - 上游 CodeBuddy 属腾讯系商业产品，本项目是其**非官方 OpenAI 兼容网关**；使用其账号做 API 网关涉及目标平台服务条款与账号风险，作者不对账号封禁、条款违约或使用结果负责
 
@@ -361,7 +387,8 @@ curl -s http://localhost:7863/v1/chat/completions \
 | 脚本 | 用途 |
 |---|---|
 | `./login.sh` | OAuth 登录 → 落盘 auth → 重启容器 |
-| `./signin.sh [auths_dir]` | 批量签到（过期先刷新） |
+| `./signin.sh [auths_dir]` | 批量签到（离线工具，直连上游，不经过网关；过期先刷新） |
+| `./checkin.sh` / `-v` / `-json` | 手动触发网关签到并排成表格（`-v` 附问题明细；`-json` 原始输出） |
 | `./credit.sh` / `./credit.sh -json` | 积分日报（美化 / 原始 JSON） |
 
 ## 🛠️ 开发

--- a/checkin.sh
+++ b/checkin.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# checkin.sh — 手动签到并把结果排成人类可读的表格
+#
+# 用法:
+#   ./checkin.sh              # 表格输出（默认）
+#   ./checkin.sh -json        # 原始 JSON（脚本/管道用）
+#   ./checkin.sh -v           # 表格 + 问题明细
+#
+# 依赖: curl、jq（jq 缺失时自动回退为原始 JSON）
+#
+# 环境变量:
+#   WB2A_CONFIG  配置文件路径（默认 ./config.json，用于读取端口与 api_key）
+#   WB2A_URL     直接指定服务地址（如 http://1.2.3.4:7863），设置后忽略配置文件
+set -euo pipefail
+cd "$(dirname "$0")"
+
+MODE=table
+VERBOSE=0
+case "${1:-}" in
+    "") ;;
+    -json|--json) MODE=json ;;
+    -v|--verbose) VERBOSE=1 ;;
+    *) echo "未知参数: $1（可用 -json / -v）" >&2; exit 2 ;;
+esac
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "需要 curl" >&2
+    exit 1
+fi
+HAS_JQ=1
+command -v jq >/dev/null 2>&1 || HAS_JQ=0
+
+# ─── 解析服务地址与密钥：优先 WB2A_URL，其次 config.json ──────────────────────
+CFG=${WB2A_CONFIG:-config.json}
+PORT=7863
+KEY=""
+if [[ -f "$CFG" ]] && [[ "$HAS_JQ" == "1" ]]; then
+    LISTEN=$(jq -r '.listen // ":7863"' "$CFG")
+    PORT=${LISTEN##*:}
+    KEY=$(jq -r '.api_key // ""' "$CFG")
+fi
+PORT=${PORT:-7863}
+BASE=${WB2A_URL:-http://localhost:$PORT}
+
+AUTH=()
+[[ -n "$KEY" ]] && AUTH=(-H "Authorization: Bearer $KEY")
+
+# ─── 调用签到接口（-s 静默，-w 单独取状态码，便于区分 HTTP 错误与签到结果）───
+# curl 连接失败时本身返回非 0，须用 || true 兜住（否则 set -e 会让脚本静默退出，
+# 打不出下面那句人话提示）；失败时 RESP 为空，CODE 归一为 000。
+RESP=$(curl -s -w $'\n%{http_code}' -X POST "$BASE/checkin" ${AUTH+"${AUTH[@]}"} || true)
+if [[ -z "$RESP" ]]; then
+    RESP=$'\n000'
+fi
+CODE=${RESP##*$'\n'}
+BODY=${RESP%$'\n'*}
+
+if [[ "$CODE" != "200" ]]; then
+    MSG=$BODY
+    if [[ "$HAS_JQ" == "1" ]]; then
+        MSG=$(printf '%s' "$BODY" | jq -r '.error.message // .' 2>/dev/null || printf '%s' "$BODY")
+    fi
+    case "$CODE" in
+        401) echo "鉴权失败（401）：api_key 与 config.json 不一致" >&2 ;;
+        409) echo "已有签到正在执行（409）：稍后重试即可" >&2 ;;
+        405) echo "服务版本过旧（405）：镜像不含 /checkin，请 docker compose up -d --build" >&2 ;;
+        503) echo "签到接口未启用（503）" >&2 ;;
+        000) echo "连不上 $BASE：服务未启动或端口不对" >&2 ;;
+        *)   echo "请求失败（HTTP $CODE）" >&2 ;;
+    esac
+    printf '%s\n' "$MSG" >&2
+    exit 1
+fi
+
+if [[ "$MODE" == "json" ]] || [[ "$HAS_JQ" == "0" ]]; then
+    printf '%s\n' "$BODY"
+    exit 0
+fi
+
+# ─── 表格渲染 ───────────────────────────────────────────────────────────────
+# 中文/emoji 按 2 格宽计算（column -t 按字节补齐会错位，故自己算宽度）。
+printf '%s' "$BODY" | jq -r '
+def w: explode | map(
+      if (. >= 4352   and . <= 44415)   # CJK 符号与标点
+      or (. >= 11904  and . <= 55215)   # 汉字、假名、韩文
+      or (. >= 63744  and . <= 64255)   # CJK 兼容
+      or (. >= 65072  and . <= 65103)   # CJK 兼容形式
+      or (. >= 65280  and . <= 65519)   # 全角形式
+      or (. >= 127744 and . <= 129791)  # emoji
+      then 2 else 1 end) | add // 0;
+def pad($n): . as $s | $s + (" " * ([($n - ($s | w)), 0] | max));
+# 状态用中文，一眼能看懂；未识别的状态原样输出，避免静默吞掉新状态。
+def zh: if . == "ok" then "成功" elif . == "already" then "已签到"
+        elif . == "skipped" then "跳过" elif . == "fail" then "失败"
+        else . end;
+["状态", "账号", "积分", "UID"] as $h
+| [.accounts[] | {
+      s: (.status | zh),
+      n: ((.nickname // "") | if . == "" then "-" else . end),
+      c: ((.credits // 0) | tostring),
+      u: (.uid[0:8])
+  }] as $r
+| (([$r[].s | w] + [$h[0] | w] | max) + 2) as $w1
+| (([$r[].n | w] + [$h[1] | w] | max) + 2) as $w2
+| (([$r[].c | w] + [$h[2] | w] | max) + 2) as $w3
+| ($h | [(.[0] | pad($w1)), (.[1] | pad($w2)), (.[2] | pad($w3)), .[3]] | join("")),
+  ($r[] | [(.s | pad($w1)), (.n | pad($w2)), (.c | pad($w3)), .u] | join("")),
+  "",
+  ("合计 \(.total)  成功 \(.ok)  已签到 \(.already)  失败 \(.failed)  跳过 \(.skipped)")
+'
+
+# ─── -v：只补充真正有问题的账号明细 ─────────────────────────────────────────
+# "已签到"是幂等成功，即便上游返回 400 报文也不算问题，一律不展示。
+if [[ "$VERBOSE" == "1" ]]; then
+    DETAILS=$(printf '%s' "$BODY" | jq -r '
+      .accounts[]
+      | select(.status != "already" and .status != "ok" and (.detail // "") != "")
+      | "  ! \(.nickname // "-") (\(.uid[0:8])) [\(.status)]: \(.detail)"')
+    if [[ -n "$DETAILS" ]]; then
+        printf '\n问题明细:\n%s\n' "$DETAILS"
+    fi
+fi

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	Schedule struct {
 		CheckinHours   []int `json:"checkin_hours"`   // [9,21]
 		KeepaliveHours []int `json:"keepalive_hours"` // [22]
+		// CheckinOnStart 启动时补一次签到（主机/容器停机错过整点签到时的补偿），默认 true。
+		CheckinOnStart bool `json:"checkin_on_start"`
 	} `json:"schedule"`
 
 	Upstream struct {
@@ -82,6 +84,9 @@ func Default() *Config {
 	c.Cooldown.SoftRate = "60s"
 	c.Schedule.CheckinHours = []int{9, 21}
 	c.Schedule.KeepaliveHours = []int{22}
+	// 布尔零值为 false，故默认值必须在 Default 里显式置 true；
+	// config 文件写 "checkin_on_start": false 才关闭（未出现的键保持 true）。
+	c.Schedule.CheckinOnStart = true
 	c.Upstream.TimeoutSeconds = 120
 	// HeaderTimeoutSeconds/IdleTimeoutSeconds 默认 0（未设置态），回落见 normalize()。
 	c.Upstream.HeaderTimeoutSeconds = 0

--- a/cmd/server/config_test.go
+++ b/cmd/server/config_test.go
@@ -219,3 +219,26 @@ func TestBadSessionTTL(t *testing.T) {
 		t.Fatal("want error for bad session_sticky.ttl")
 	}
 }
+
+func TestCheckinOnStartDefaultTrue(t *testing.T) {
+	c := Default()
+	if err := c.normalize(); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !c.Schedule.CheckinOnStart {
+		t.Error("checkin_on_start 默认必须为 true（停机错过签到要能补偿）")
+	}
+}
+
+func TestCheckinOnStartCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "c.json")
+	os.WriteFile(fp, []byte(`{"schedule":{"checkin_on_start":false}}`), 0o600)
+	c, err := Load(fp)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if c.Schedule.CheckinOnStart {
+		t.Error("显式 false 应关闭启动补签")
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,11 +107,21 @@ func main() {
 		StickyCount:  sessCount,
 		RedisMode:    redisMode,
 		SoftCooldown: cfg.SoftRateDur,
+		Checkin:      sch.CheckinAll,
 	})
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	go sch.Run(ctx)
+	// 启动补签：主机/容器停机错过整点签到（checkin_hours）时，起来即补一次。
+	// 幂等：当天已签到由上游拒绝并按 already 记账；后台执行不阻塞监听。
+	if cfg.Schedule.CheckinOnStart {
+		go func() {
+			if _, err := sch.CheckinAll(); err != nil {
+				log.Printf("startup checkin skipped: %v", err)
+			}
+		}()
+	}
 
 	srv := &http.Server{
 		Addr:              cfg.Listen,

--- a/config.example.json
+++ b/config.example.json
@@ -8,7 +8,8 @@
   },
   "schedule": {
     "checkin_hours": [9, 21],
-    "keepalive_hours": [22]
+    "keepalive_hours": [22],
+    "checkin_on_start": true
   },
   "upstream": {
     "timeout_seconds": 120,

--- a/internal/scheduler/checkin_test.go
+++ b/internal/scheduler/checkin_test.go
@@ -1,0 +1,275 @@
+package scheduler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"workbuddy2api/internal/auth"
+	"workbuddy2api/internal/pool"
+	"workbuddy2api/internal/upstream"
+)
+
+// newCheckinFixture 构建带 fake 上游的调度器：remain 为签到后余额；
+// already=true 时 daily-checkin 返回业务错误（模拟上游"今天已签到"）。
+func newCheckinFixture(t *testing.T, remain int64, already bool) (*Scheduler, *pool.Pool, *fakeUpstream) {
+	t.Helper()
+	f := &fakeUpstream{resourceRemain: remain, already: already}
+	srv := f.server()
+	t.Cleanup(srv.Close)
+
+	p := pool.New("")
+	up := &upstream.Client{
+		HTTP:          srv.Client(),
+		ChatBaseCN:    srv.URL,
+		BillingBaseCN: srv.URL,
+	}
+	return New(Config{Pool: p, Upstream: up}), p, f
+}
+
+func TestCheckinAllReportsOutcomes(t *testing.T) {
+	s, p, _ := newCheckinFixture(t, 500, false)
+	p.Add(&auth.Auth{UID: "u1", Nickname: "nick", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+
+	out, err := s.CheckinAll()
+	if err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("outcomes=%d want 1", len(out))
+	}
+	oc := out[0]
+	if oc.UID != "u1" || oc.Status != CheckinOK {
+		t.Errorf("outcome=%+v want u1/ok", oc)
+	}
+	if oc.Credits == nil || *oc.Credits != 500 {
+		t.Errorf("credits=%v want 500", oc.Credits)
+	}
+	if oc.Nickname != "nick" {
+		t.Errorf("nickname=%q", oc.Nickname)
+	}
+}
+
+func TestCheckinAllMarksAlreadyCheckin(t *testing.T) {
+	s, p, _ := newCheckinFixture(t, 300, true)
+	p.Add(&auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+
+	out, err := s.CheckinAll()
+	if err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if out[0].Status != CheckinAlready {
+		t.Errorf("status=%s want already（上游 code!=0 今天已签到）", out[0].Status)
+	}
+	// 已签到也要照常查余额并解冻：账号余额恢复即应复活。
+	if out[0].Credits == nil || *out[0].Credits != 300 {
+		t.Errorf("credits=%v want 300", out[0].Credits)
+	}
+}
+
+// TestCheckinAlreadyHasNoErrorDetail "今天已签到"是幂等成功，回执里不该出现
+// 上游 400 报文——否则调用方会把正常状态读成失败。
+func TestCheckinAlreadyHasNoErrorDetail(t *testing.T) {
+	s, p, _ := newCheckinFixture(t, 300, true)
+	p.Add(&auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+
+	out, err := s.CheckinAll()
+	if err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if out[0].Status != CheckinAlready {
+		t.Fatalf("status=%s want already", out[0].Status)
+	}
+	if out[0].Detail != "" {
+		t.Errorf("detail=%q want empty（已签到不是错误，不该带报错正文）", out[0].Detail)
+	}
+}
+
+func TestCheckinAllSkipsDisabledAndCredentialLess(t *testing.T) {
+	s, p, f := newCheckinFixture(t, 100, false)
+	p.Add(&auth.Auth{UID: "off", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+	p.Add(&auth.Auth{UID: "norefresh", AccessToken: "at", ExpiresAt: 9999999999})
+	p.Disable("off", "12153 session dead")
+
+	out, err := s.CheckinAll()
+	if err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("outcomes=%d want 2", len(out))
+	}
+	for _, oc := range out {
+		if oc.Status != CheckinSkipped {
+			t.Errorf("%s status=%s want skipped (%s)", oc.UID, oc.Status, oc.Detail)
+		}
+	}
+	if f.checkinCalls.Load() != 0 {
+		t.Errorf("checkin calls=%d want 0（禁用/无凭证都不该打上游）", f.checkinCalls.Load())
+	}
+}
+
+func TestCheckinAllRefreshesExpiredToken(t *testing.T) {
+	s, p, f := newCheckinFixture(t, 100, false)
+	// ExpiresAt=1 → 早已过期，必须先刷新再签到，否则签到必然 401。
+	a := &auth.Auth{UID: "u1", AccessToken: "old", RefreshToken: "rt", ExpiresAt: 1}
+	p.Add(a)
+
+	if _, err := s.CheckinAll(); err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if f.refreshCalls.Load() != 1 {
+		t.Errorf("refresh calls=%d want 1", f.refreshCalls.Load())
+	}
+	if f.checkinCalls.Load() != 1 {
+		t.Errorf("checkin calls=%d want 1", f.checkinCalls.Load())
+	}
+	if a.AccessToken != "new" {
+		t.Errorf("token=%q want new", a.AccessToken)
+	}
+}
+
+// TestCheckinAllStillChecksInWhenRefreshFailsButTokenAlive 刷新接口抖动但 access token
+// 还没真正过期时，签到仍应照常执行，不能因"提前补票"失败而白白跳过当天签到。
+func TestCheckinAllStillChecksInWhenRefreshFailsButTokenAlive(t *testing.T) {
+	f := &fakeUpstream{resourceRemain: 100, refreshFails: true}
+	srv := f.server()
+	defer srv.Close()
+
+	p := pool.New("")
+	// 10 分钟内过期 → 触发 NeedsRefresh(10m)，但此刻 token 仍有效（尚未过期）。
+	a := &auth.Auth{UID: "u1", AccessToken: "still-valid", RefreshToken: "rt",
+		ExpiresAt: time.Now().Add(5 * time.Minute).Unix()}
+	p.Add(a)
+
+	up := &upstream.Client{HTTP: srv.Client(), ChatBaseCN: srv.URL, BillingBaseCN: srv.URL}
+	s := New(Config{Pool: p, Upstream: up})
+
+	out, err := s.CheckinAll()
+	if err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if f.checkinCalls.Load() != 1 {
+		t.Fatalf("checkin calls=%d want 1（token 仍有效就必须签到）", f.checkinCalls.Load())
+	}
+	if out[0].Status != CheckinOK {
+		t.Errorf("status=%s want ok (%s)", out[0].Status, out[0].Detail)
+	}
+}
+
+// TestCheckinAllFailsWhenRefreshFailsAndTokenExpired 真过期且刷新失败 → fail，
+// 不做无谓的上游签到调用。
+func TestCheckinAllFailsWhenRefreshFailsAndTokenExpired(t *testing.T) {
+	f := &fakeUpstream{resourceRemain: 100, refreshFails: true}
+	srv := f.server()
+	defer srv.Close()
+
+	p := pool.New("")
+	a := &auth.Auth{UID: "u1", AccessToken: "expired", RefreshToken: "rt", ExpiresAt: 1}
+	p.Add(a)
+
+	up := &upstream.Client{HTTP: srv.Client(), ChatBaseCN: srv.URL, BillingBaseCN: srv.URL}
+	s := New(Config{Pool: p, Upstream: up})
+
+	out, err := s.CheckinAll()
+	if err != nil {
+		t.Fatalf("CheckinAll: %v", err)
+	}
+	if f.checkinCalls.Load() != 0 {
+		t.Errorf("checkin calls=%d want 0（token 已过期，签到必然 401）", f.checkinCalls.Load())
+	}
+	if out[0].Status != CheckinFail {
+		t.Errorf("status=%s want fail", out[0].Status)
+	}
+}
+
+// TestCheckinAllBusyRejectsConcurrent 并发签到必须被拒（ErrBusy），
+// 避免手动接口与定时/启动补签同时重放上游。
+func TestCheckinAllBusyRejectsConcurrent(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enterOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 所有请求都阻塞在 release 上，保证首个签到在后续调用期间仍持锁。
+		enterOnce.Do(func() { close(entered) })
+		<-release
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/daily-checkin"):
+			w.Write([]byte(`{"code":0,"msg":"ok","data":{}}`))
+		case strings.HasSuffix(r.URL.Path, "/get-user-resource"):
+			w.Write([]byte(`{"code":0,"data":{"Response":{"Data":{"Accounts":[{"CycleCapacitySize":100,"CycleCapacityRemain":10,"CycleCapacityUsed":0}]}}}}`))
+		default:
+			http.Error(w, "not found", 404)
+		}
+	}))
+	defer srv.Close()
+
+	p := pool.New("")
+	p.Add(&auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+	up := &upstream.Client{HTTP: srv.Client(), ChatBaseCN: srv.URL, BillingBaseCN: srv.URL}
+	s := New(Config{Pool: p, Upstream: up})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.CheckinAll()
+		done <- err
+	}()
+	waitEntered(t, entered)
+
+	if _, err := s.CheckinAll(); !errors.Is(err, ErrBusy) {
+		t.Errorf("err=%v want ErrBusy", err)
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Errorf("first CheckinAll: %v", err)
+	}
+
+	// 首个签到结束后互斥已归还：应能再次签到（release 已关闭，请求直接放行）。
+	if _, err := s.CheckinAll(); err != nil {
+		t.Errorf("after release CheckinAll: %v", err)
+	}
+}
+
+// TestRunCheckinNowSwallowsConcurrent 定时入口与手动签到撞车只记日志，不 panic、不阻塞。
+func TestRunCheckinNowSwallowsConcurrent(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enterOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enterOnce.Do(func() { close(entered) })
+		<-release
+		w.Write([]byte(`{"code":0,"msg":"ok","data":{}}`))
+	}))
+	defer srv.Close()
+
+	p := pool.New("")
+	p.Add(&auth.Auth{UID: "u1", AccessToken: "at", RefreshToken: "rt", ExpiresAt: 9999999999})
+	up := &upstream.Client{HTTP: srv.Client(), ChatBaseCN: srv.URL, BillingBaseCN: srv.URL}
+	s := New(Config{Pool: p, Upstream: up})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.CheckinAll()
+		done <- err
+	}()
+	waitEntered(t, entered)
+
+	s.RunCheckinNow() // 撞车：必须吞掉 ErrBusy 并立即返回
+	close(release)
+	if err := <-done; err != nil {
+		t.Errorf("CheckinAll: %v", err)
+	}
+}
+
+// waitEntered 等待首次上游请求抵达，超时即失败（避免 fake 行为变化时测试静默挂死）。
+func waitEntered(t *testing.T, entered <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("checkin never reached upstream")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,16 +1,45 @@
 // Package scheduler 定时任务：每日签到（09/21点）+ token keepalive（22点）。
 // 签到成功后重新查余额，余额 > 0 的冷却账号自动解冻。
+// 签到除定时整点触发外，另有启动补签（主机/容器停机错过整点）与 HTTP 手动签到两个入口，
+// 三者共用 CheckinAll 的同一套逻辑（幂等：当天已签到由上游返回业务错误，按 already 记账）。
 package scheduler
 
 import (
 	"context"
 	"errors"
 	"log"
+	"sync"
 	"time"
 
 	"workbuddy2api/internal/pool"
 	"workbuddy2api/internal/upstream"
 )
+
+// checkinRefreshSkew 签到前判定"token 是否临近过期"的时间窗口。
+// 长时间停机后 access token 往往已过期，不先刷新则签到必然 401 白跑。
+const checkinRefreshSkew = 10 * time.Minute
+
+// CheckinStatus 单账号签到结果状态。
+type CheckinStatus string
+
+const (
+	CheckinOK      CheckinStatus = "ok"      // 签到成功
+	CheckinAlready CheckinStatus = "already" // 上游判定今天已签到（幂等重复，视为正常）
+	CheckinFail    CheckinStatus = "fail"    // 刷新 token / 签到 / 余额查询失败
+	CheckinSkipped CheckinStatus = "skipped" // 禁用账号或无有效凭证，未参与
+)
+
+// CheckinOutcome 单账号签到结果（供手动签到接口回执与日志汇总）。
+type CheckinOutcome struct {
+	UID      string        `json:"uid"`
+	Nickname string        `json:"nickname,omitempty"`
+	Status   CheckinStatus `json:"status"`
+	Credits  *int64        `json:"credits,omitempty"` // 签到后余额（余额查询成功才有值）
+	Detail   string        `json:"detail,omitempty"`  // 失败/跳过原因
+}
+
+// ErrBusy 已有一次签到正在执行（手动入口与定时/启动补签撞车）。
+var ErrBusy = errors.New("checkin already running")
 
 // Config 调度器依赖。
 type Config struct {
@@ -23,6 +52,8 @@ type Config struct {
 // Scheduler 调度器。
 type Scheduler struct {
 	cfg Config
+	// checkinMu 串行化签到：手动接口与定时/启动补签互斥，避免同一时刻重复打上游签到接口。
+	checkinMu sync.Mutex
 }
 
 // New 构建。
@@ -82,28 +113,111 @@ func contains(hours []int, h int) bool {
 	return false
 }
 
-// RunCheckinNow 立即对所有账号执行签到 + 余额刷新 + 解冻。
-// 冷却中的账号也参与（签到就是为了解冻它们）；禁用的跳过。
+// RunCheckinNow 定时触发的立即签到：逐账号结果由 CheckinAll 记日志，此处只兜住"撞车跳过"。
 func (s *Scheduler) RunCheckinNow() {
-	for _, st := range s.cfg.Pool.List() {
+	if _, err := s.CheckinAll(); err != nil {
+		log.Printf("scheduled checkin skipped: %v", err)
+	}
+}
+
+// CheckinAll 全量签到：按需刷新 token → daily-checkin → 查余额 → 解冻冷却账号。
+// 冷却中的账号也参与（签到就是为了解冻它们）；禁用的跳过。
+// 同一时刻只允许一次签到在跑，重复调用返回 ErrBusy。
+func (s *Scheduler) CheckinAll() ([]CheckinOutcome, error) {
+	if !s.checkinMu.TryLock() {
+		return nil, ErrBusy
+	}
+	defer s.checkinMu.Unlock()
+
+	statuses := s.cfg.Pool.List()
+	out := make([]CheckinOutcome, 0, len(statuses))
+	var okN, alreadyN, failN, skipN int
+	for _, st := range statuses {
+		oc := CheckinOutcome{UID: st.UID, Nickname: st.Nickname}
 		if st.Disabled {
+			oc.Status, oc.Detail = CheckinSkipped, "disabled"
+			skipN++
+			out = append(out, oc)
 			continue
 		}
 		a := s.cfg.Pool.AuthByUID(st.UID)
 		if a == nil || a.RefreshToken == "" {
+			oc.Status, oc.Detail = CheckinSkipped, "no credentials"
+			skipN++
+			out = append(out, oc)
 			continue
 		}
+		// 停机跨过 token 有效期（关机过夜/容器长期停跑）时先补一次刷新，否则签到必然失败。
+		if a.NeedsRefresh(checkinRefreshSkew) {
+			if err := s.cfg.Upstream.RefreshToken(a); err != nil {
+				log.Printf("checkin %s refresh: %v", st.UID, err)
+				var ue *upstream.Error
+				if errors.As(err, &ue) && ue.Kind == upstream.ErrSessionDead {
+					s.cfg.Pool.Disable(st.UID, "12153 session dead")
+					oc.Status, oc.Detail = CheckinFail, "refresh: "+err.Error()
+					failN++
+					out = append(out, oc)
+					continue
+				}
+				// 刷新只是"提前补票"：token 若仍有效，继续照常签到（否则刷新接口抖动
+				// 会让本可成功的签到被白白跳过）；真正过期才判定失败。
+				if a.NeedsRefresh(0) {
+					oc.Status, oc.Detail = CheckinFail, "refresh: "+err.Error()
+					failN++
+					out = append(out, oc)
+					continue
+				}
+			} else if err := a.SaveAtomic(); err != nil {
+				// 刷新成功但落盘失败：重启会用旧 token，必须暴露。
+				log.Printf("checkin %s save: %v", st.UID, err)
+			}
+		}
+		// 签到返回错误（含"今天已签到"）也继续查余额：余额恢复即可解冻账号。
 		if err := s.cfg.Upstream.DailyCheckin(a); err != nil {
-			log.Printf("checkin %s: %v", st.UID, err)
-			// 已签到等业务错误也继续走余额查询
+			if upstream.IsAlreadyCheckin(err) {
+				// "今天已签到"是幂等成功，不是错误：不填 detail，免得回执里
+				// 出现一整段 400 报文、被误读成签到失败。
+				oc.Status = CheckinAlready
+			} else {
+				oc.Status = CheckinFail
+				oc.Detail = err.Error()
+				log.Printf("checkin %s: %v", st.UID, err)
+			}
+		} else {
+			oc.Status = CheckinOK
 		}
 		remain, err := s.cfg.Upstream.UserResource(a)
 		if err != nil {
 			log.Printf("user-resource %s: %v", st.UID, err)
+			oc.Status = CheckinFail
+			oc.Detail = joinDetail(oc.Detail, "resource: "+err.Error())
+			failN++
+			out = append(out, oc)
 			continue
 		}
 		s.cfg.Pool.ReenableIfCredits(st.UID, remain)
+		oc.Credits = &remain
+		switch oc.Status {
+		case CheckinOK:
+			okN++
+		case CheckinAlready:
+			alreadyN++
+		default:
+			failN++
+		}
+		out = append(out, oc)
 	}
+	log.Printf("checkin done: total=%d ok=%d already=%d fail=%d skipped=%d",
+		len(statuses), okN, alreadyN, failN, skipN)
+	return out, nil
+}
+
+// joinDetail 拼接多段原因，避免后一段覆盖前一段的失败信息。
+func joinDetail(existing, add string) string {
+	if existing == "" {
+		return add
+	}
+	return existing + "; " + add
 }
 
 // RunKeepaliveNow 立即对所有账号刷新 token；session 死亡的自动禁用。

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -43,10 +43,14 @@ func TestNextFireMergesSchedules(t *testing.T) {
 }
 
 // fakeUpstream 同时模拟 billing 与 refresh。
+// already=true 时 daily-checkin 返回业务错误（code=10001 "今天已签到"），
+// 用于验证签到入口把"已签到"归类为 already 而非 fail。
 type fakeUpstream struct {
 	checkinCalls   atomic.Int32
 	refreshCalls   atomic.Int32
 	resourceRemain int64
+	already        bool // true 时 daily-checkin 返回业务错误（今天已签到）
+	refreshFails   bool // true 时 refresh 返回 500，模拟刷新接口抖动
 }
 
 func (f *fakeUpstream) server() *httptest.Server {
@@ -54,12 +58,21 @@ func (f *fakeUpstream) server() *httptest.Server {
 		switch {
 		case strings.HasSuffix(r.URL.Path, "/daily-checkin"):
 			f.checkinCalls.Add(1)
+			if f.already {
+				w.Write([]byte(`{"code":10001,"msg":"今天已签到","data":{}}`))
+				return
+			}
 			w.Write([]byte(`{"code":0,"msg":"ok","data":{}}`))
 		case strings.HasSuffix(r.URL.Path, "/get-user-resource"):
 			w.Write([]byte(`{"code":0,"data":{"Response":{"Data":{"Accounts":[{"CycleCapacitySize":100,"CycleCapacityRemain":` +
 				jsonI64(f.resourceRemain) + `,"CycleCapacityUsed":0}]}}}}`))
 		case strings.HasSuffix(r.URL.Path, "/token/refresh"):
 			f.refreshCalls.Add(1)
+			if f.refreshFails {
+				w.WriteHeader(500)
+				w.Write([]byte(`boom`))
+				return
+			}
 			w.Write([]byte(`{"code":0,"data":{"accessToken":"new","expiresIn":3600}}`))
 		default:
 			http.Error(w, "not found", 404)

--- a/internal/server/checkin_test.go
+++ b/internal/server/checkin_test.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"workbuddy2api/internal/auth"
+	"workbuddy2api/internal/scheduler"
+	"workbuddy2api/internal/upstream"
+)
+
+func int64p(v int64) *int64 { return &v }
+
+// TestCheckinEndpointReportsSummary POST /checkin 汇总各账号结果并透出明细。
+func TestCheckinEndpointReportsSummary(t *testing.T) {
+	p := testPoolWith(&auth.Auth{UID: "u1", AccessToken: "at", ExpiresAt: 9999999999})
+	called := 0
+	h := NewHandler(Config{
+		Pool:     p,
+		Upstream: upstream.New(),
+		APIKey:   "secret",
+		Checkin: func() ([]scheduler.CheckinOutcome, error) {
+			called++
+			return []scheduler.CheckinOutcome{
+				{UID: "u1", Nickname: "nick", Status: scheduler.CheckinOK, Credits: int64p(1000)},
+				{UID: "u2", Status: scheduler.CheckinAlready},
+				{UID: "u3", Status: scheduler.CheckinFail, Detail: "boom"},
+				{UID: "u4", Status: scheduler.CheckinSkipped, Detail: "disabled"},
+			}, nil
+		},
+	})
+
+	// 无 token → 401（与 /status 同级，须走同一鉴权），且不得触发签到。
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/checkin", nil))
+	if rec.Code != 401 {
+		t.Fatalf("no token: code=%d want 401", rec.Code)
+	}
+	if called != 0 {
+		t.Fatal("checkin must not run without valid api key")
+	}
+
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/checkin", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	h.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if called != 1 {
+		t.Fatalf("checkin calls=%d want 1", called)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("not json: %v", err)
+	}
+	want := map[string]float64{"total": 4, "ok": 1, "already": 1, "failed": 1, "skipped": 1}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("%s=%v want %v", k, got[k], v)
+		}
+	}
+	accounts, ok := got["accounts"].([]any)
+	if !ok || len(accounts) != 4 {
+		t.Fatalf("accounts=%v", got["accounts"])
+	}
+	first, _ := accounts[0].(map[string]any)
+	if first["uid"] != "u1" || first["status"] != "ok" || first["credits"] != float64(1000) {
+		t.Errorf("first account=%v", first)
+	}
+	// 已签到账号不应被当成失败暴露给调用方。
+	second, _ := accounts[1].(map[string]any)
+	if second["status"] != "already" {
+		t.Errorf("second account=%v", second)
+	}
+}
+
+// TestCheckinEndpointBusyReturns409 已有签到在跑 → 409，提示可重试。
+func TestCheckinEndpointBusyReturns409(t *testing.T) {
+	p := testPoolWith(&auth.Auth{UID: "u1", AccessToken: "at", ExpiresAt: 9999999999})
+	h := NewHandler(Config{
+		Pool:     p,
+		Upstream: upstream.New(),
+		Checkin:  func() ([]scheduler.CheckinOutcome, error) { return nil, scheduler.ErrBusy },
+	})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/checkin", nil))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("code=%d want 409", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "already running") {
+		t.Errorf("body=%s", rec.Body.String())
+	}
+}
+
+// TestCheckinEndpointUnavailable 未注入签到函数时明确 503，而不是 500 或空指针。
+func TestCheckinEndpointUnavailable(t *testing.T) {
+	p := testPoolWith(&auth.Auth{UID: "u1", AccessToken: "at", ExpiresAt: 9999999999})
+	h := NewHandler(Config{Pool: p, Upstream: upstream.New()})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/checkin", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("code=%d want 503", rec.Code)
+	}
+}
+
+// TestCheckinEndpointRejectsGet 签到有副作用，只接受 POST（Go 1.22 路由按方法匹配）。
+func TestCheckinEndpointRejectsGet(t *testing.T) {
+	p := testPoolWith(&auth.Auth{UID: "u1", AccessToken: "at", ExpiresAt: 9999999999})
+	h := NewHandler(Config{
+		Pool:     p,
+		Upstream: upstream.New(),
+		Checkin:  func() ([]scheduler.CheckinOutcome, error) { return nil, nil },
+	})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/checkin", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("code=%d want 405", rec.Code)
+	}
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"workbuddy2api/internal/auth"
 	"workbuddy2api/internal/pool"
+	"workbuddy2api/internal/scheduler"
 	"workbuddy2api/internal/session"
 	"workbuddy2api/internal/upstream"
 )
@@ -31,6 +32,8 @@ type Config struct {
 	RedisMode    string
 	SoftCooldown time.Duration // 429 冷却，默认 60s
 	RefreshSkew  time.Duration // token 提前刷新窗口，默认 10m
+	// Checkin 手动签到入口（main 注入 scheduler.CheckinAll）；nil = 接口不可用。
+	Checkin func() ([]scheduler.CheckinOutcome, error)
 }
 
 // Handler 主路由。
@@ -54,6 +57,7 @@ func NewHandler(cfg Config) *Handler {
 	h.mux.HandleFunc("POST /v1/chat/completions", h.withAuth(h.chatCompletions))
 	h.mux.HandleFunc("GET /v1/models", h.withAuth(h.models))
 	h.mux.HandleFunc("GET /status", h.withAuth(h.status))
+	h.mux.HandleFunc("POST /checkin", h.withAuth(h.checkin))
 	h.mux.HandleFunc("GET /healthz", h.healthz)
 	return h
 }
@@ -73,6 +77,46 @@ func (h *Handler) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 		next(w, r)
 	}
+}
+
+// checkin 手动触发全量签到（定时任务错过整点时的补签入口）。
+// 复用调度器同一套逻辑：按需刷新 token → 签到 → 查余额 → 解冻冷却账号。
+// 已有签到在跑时返回 409（幂等重试即可：重复签到由上游判定 already）。
+func (h *Handler) checkin(w http.ResponseWriter, r *http.Request) {
+	if h.cfg.Checkin == nil {
+		writeOpenAIError(w, http.StatusServiceUnavailable, "checkin_unavailable", "checkin not configured")
+		return
+	}
+	outcomes, err := h.cfg.Checkin()
+	if err != nil {
+		status := http.StatusInternalServerError
+		if errors.Is(err, scheduler.ErrBusy) {
+			status = http.StatusConflict
+		}
+		writeOpenAIError(w, status, "checkin_failed", err.Error())
+		return
+	}
+	var okN, alreadyN, failN, skipN int
+	for _, o := range outcomes {
+		switch o.Status {
+		case scheduler.CheckinOK:
+			okN++
+		case scheduler.CheckinAlready:
+			alreadyN++
+		case scheduler.CheckinFail:
+			failN++
+		default:
+			skipN++
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"total":    len(outcomes),
+		"ok":       okN,
+		"already":  alreadyN,
+		"failed":   failN,
+		"skipped":  skipN,
+		"accounts": outcomes,
+	})
 }
 
 func (h *Handler) healthz(w http.ResponseWriter, r *http.Request) {

--- a/internal/upstream/client.go
+++ b/internal/upstream/client.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -69,6 +70,9 @@ var hardMarkers = []string{
 }
 
 var sessionDeadMarkers = []string{"Offline user session not found", "12153"}
+
+// alreadyCheckinMarkers "今天已签到"关键词（上游对重复签到返回 code!=0，实测 code=10001 "今天已签到"）。
+var alreadyCheckinMarkers = []string{"已签到", "already"}
 
 // Classify 按 HTTP 状态码 + body 判定错误类别。
 func Classify(status int, body string) ErrKind {
@@ -471,6 +475,22 @@ func (c *Client) DailyCheckin(a *auth.Auth) error {
 	BillingHeaders(req, a)
 	_, err = c.doJSON(req)
 	return err
+}
+
+// IsAlreadyCheckin 报告 err 是否表示"今天已签到"（上游幂等拒绝重复签到）。
+// 只认带分类的 *Error（业务 code 或 HTTP 错误）：网络层/解析层错误不得当作幂等成功，
+// 否则停机补签遇到抖动会误记为 already，账号当天实际未签到却被判定正常。
+func IsAlreadyCheckin(err error) bool {
+	var ue *Error
+	if !errors.As(err, &ue) {
+		return false
+	}
+	for _, m := range alreadyCheckinMarkers {
+		if strings.Contains(ue.Msg, m) || strings.Contains(strings.ToLower(ue.Msg), strings.ToLower(m)) {
+			return true
+		}
+	}
+	return false
 }
 
 func truncate(s string, n int) string {

--- a/internal/upstream/client_test.go
+++ b/internal/upstream/client_test.go
@@ -387,3 +387,24 @@ func TestChatHTTPNilFallsBackToHTTP(t *testing.T) {
 		t.Error("chatHTTP() should fall back to HTTP when ChatHTTP is nil")
 	}
 }
+
+func TestIsAlreadyCheckin(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"业务码已签到", &Error{Kind: ErrClient, Status: 400, Msg: `code=10001 msg=今天已签到`}, true},
+		{"英文 already", &Error{Kind: ErrClient, Status: 400, Msg: "already checked in today"}, true},
+		{"余额不足", &Error{Kind: ErrHardCredit, Status: 402, Msg: "余额不足"}, false},
+		{"服务端错误", &Error{Kind: ErrServer, Status: 500, Msg: "boom"}, false},
+		// 网络层/解析层错误没有分类，绝不能当成"已签到"，否则补偿签到会静默漏签。
+		{"网络错误", errors.New("dial tcp: connection refused"), false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		if got := IsAlreadyCheckin(c.err); got != c.want {
+			t.Errorf("%s: got=%v want=%v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## 问题

签到只由定时任务在整点触发（`schedule.checkin_hours`）。主机或容器在整点前关机、错过触发点，当天就**漏签**——而这正是最常见的场景（个人电脑夜里关机）。失败表现为：账号积分停在前一天，冷却账号无法解冻（`ErrHardCredit` 会冷却到次日 04:00 等签到恢复，见 `internal/server/handler.go` 的 `applyErrorPolicy`），只能用 `./signin.sh` 离线工具手动补。

此外，`daily-checkin` 对重复签到返回业务错误 `code=10001 今天已签到`。该错误被原样塞进结果 `detail`（一整段 400 报文含 requestId），在回执里看起来像**签到失败**，实际是幂等成功。

## 修复

**1. 手动签到接口 `POST /checkin`**（`internal/server/handler.go`）

与 `/status` 同级鉴权（`api_key` 非空时校验 Bearer），返回逐账号结果：

```json
{"total":2,"ok":1,"already":1,"failed":0,"skipped":0,
 "accounts":[{"uid":"u1","nickname":"nick","status":"ok","credits":1200},
             {"uid":"u2","status":"already","credits":800}]}
```

`status`：`ok` 成功 / `already` 今天已签到 / `fail` 失败 / `skipped` 禁用或无凭证。
已有签到在跑返回 `409`；未注入签到入口 `503`；非 POST `405`。

**2. 启动补签**（`cmd/server/main.go`、`cmd/server/config.go`）

新增 `schedule.checkin_on_start`，**默认 true**：服务/容器启动即补一次签到，后台 goroutine 执行不阻塞监听。旧配置文件不写该键也默认开启，显式 `false` 才关闭。

**3. 三入口共用同一套逻辑**（`internal/scheduler/scheduler.go`）

- 原 `RunCheckinNow` 全量逻辑抽为 `CheckinAll`，定时/启动/手动共用，既有行为不变（冷却账号照常解冻、禁用跳过、session dead 仍禁用）。
- `TryLock` 串行化，撞车返回 `ErrBusy`，避免三入口同时重放上游。
- **签到前按需刷新 token**：停机过夜后 access token 多已失效，不刷新则补签必然 401 空跑；若刷新接口抖动但 token 仍有效则继续签到，仅真过期才判失败。

**4. `"今天已签到"` 归类修正**（`internal/upstream/client.go` + scheduler）

新增 `IsAlreadyCheckin`，**只认带分类的 `*upstream.Error`**（网络层/解析层错误不得当作幂等成功，否则抖动会静默漏签）；命中即记 `already`，且不再回填 400 报文到 `detail`。

**5. 辅助脚本 `checkin.sh`**

`POST /checkin` 返回单行 JSON 不便扫读，脚本自动读取 `config.json` 的端口与 `api_key`，按显示宽度（中文/emoji 计 2 格）排成表格；`-v` 附问题明细（仅 fail/skipped），`-json` 输出原始 JSON。401/405/409/503 及连接失败均有中文提示，无 `jq` 时回退原始 JSON。

## 验证

- `go build ./...` / `go vet ./...` / `gofmt`（本次改动文件）通过
- `go test ./... -count=20` 无 flake；`go test -race ./...` 通过
- 新增 14 个用例：结果归类、禁用/无凭证跳过、过期先刷新、刷新抖动但 token 有效、真过期失败、并发 409、接口鉴权与 401/405/409/503、配置默认值与可关闭
- 真实容器端到端：`docker compose up -d --build` 后启动即输出
  `checkin done: total=4 ok=0 already=4 fail=0 skipped=0`，`POST /checkin` 返回 401（无鉴权）/ 405（GET）；`already` 的 `detail` 已为空

## 说明

- `signin.sh` 是离线工具（直连上游、不经过网关），与新的 `checkin.sh`（走网关）用途不同，README 已注明区分。
- README 同步了 API 端点表、配置字段速查、定时任务表与响应示例。
