### PR TITLE
docs: 引入 GitHub Issue Forms 模板与反馈规范

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,183 @@
+name: 缺陷报告
+description: 网关行为与预期不符（接口报错、流式异常、换号 / 冷却异常、定时任务失败等）
+title: "[Bug] 一句话描述现象，不要只写「不能用」"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]
+        > **提交前请先确认这三件事，否则 issue 会被要求补充信息或按「无法复现」关闭：**
+        >
+        > 1. 已阅读 README 的 [快速开始](https://github.com/Sliverkiss/workbuddy2api#快速开始)、[配置说明](https://github.com/Sliverkiss/workbuddy2api#配置说明) 与 [常见问题](https://github.com/Sliverkiss/workbuddy2api#常见问题)；
+        > 2. 已排除客户端自身配置问题（用下方「最小化复现」中的 curl 直调网关验证）；
+        > 3. **已剔除所有凭据与隐私信息**：`api_key`、`auths/` 中的 token、账号 uid / 手机号 / 邮箱、上游 Cookie 头。
+        >
+        > 每一项都必须填写。**不适用的写「不适用」，确实无法提供的写「无法提供」并说明原因 —— 不要留空、不要写「不知道」。**
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: 提交前自检
+      options:
+        - label: 我已按上述要求脱敏，未包含任何凭据或账号隐私信息
+          required: true
+        - label: 我已搜索过现有 issues（含已关闭），确认这不是重复问题
+          required: true
+        - label: 我已用 curl 直调网关复现，确认问题不在客户端侧
+          required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 问题摘要
+      description: 用 1–3 句话说明「做了什么 → 得到什么 → 期望什么」。禁止只写「报错了」「用不了」。
+      placeholder: |
+        调用 POST /v1/chat/completions 且 stream=true 时，客户端在收到首个正文增量前连接被切断；
+        期望是正常输出完整 SSE 帧直到 [DONE]。
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤
+      description: 从干净状态开始的最小步骤，必须可被他人照做复现。能写成命令的写成命令。
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: input
+    id: frequency
+    attributes:
+      label: 复现率与触发条件
+      description: 如「10 次中 7 次」「仅并发 ≥ 2 时」「仅当轮换到第 3 个账号时」；不稳定的问题请说明规律。
+      placeholder: 必现 / 10 次中 N 次 / 仅特定条件下必现（条件：___）
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望行为
+      description: 明确、可验证的期望结果。
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 实际观察到的结果，并粘贴报错原文（不要转述、不要只截图结论）。
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 影响范围
+      description: 受影响的端点或子系统（可多选）。
+      multiple: true
+      options:
+        - "POST /v1/chat/completions（非流式）"
+        - "POST /v1/chat/completions（流式 SSE）"
+        - "工具调用 / tool_calls"
+        - "系统提示词体系（custom / passthrough）"
+        - "账号池 / 选号 / 会话粘性"
+        - "熔断与冷却（402 / 404 / 429）"
+        - "定时任务（签到 / 活跃 / 旅行 / 保活）"
+        - "状态持久化（state.json / Upstash）"
+        - "鉴权 / 请求体上限"
+        - "其他（在下方补充）"
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: 环境信息
+      description: 逐行填写。版本号写 release tag 或 commit hash，不要写「最新版」。
+      value: |
+        - 项目版本（release tag 或 commit hash）：
+        - 部署方式（Docker Compose / 源码构建 / 其他）：
+        - 镜像 tag 或完整启动命令：
+        - Go 版本（源码构建时）：
+        - 客户端（类型 + 版本，如 Cherry Studio x.y.z / OpenAI SDK x.y.z / curl）：
+        - 操作系统与版本：
+        - 上游账号数量与状态（可用 / 冷却 / 熔断 各几个）：
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: 有效配置
+      description: 贴出实际生效的配置（`config.json` 或环境变量覆盖）。`api_key`、`upstash.token` 必须打码；未改动的字段可省略，但要说明省略。
+      render: json
+      placeholder: |
+        {
+          "listen": ":7863",
+          "server": { "max_body_mb": 8 },
+          "prompt": { "mode": "custom" },
+          "features": { "sanitize_blacklist_fingerprints": true }
+        }
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: 最小化复现：网关请求
+      description: 可直接执行的 curl（URL 与 key 打码即可），或客户端实际发出的完整请求体 JSON。必须包含 `model`、`messages`、`stream`，涉及工具调用时须含 `tools` / `tool_choice`。
+      render: shell
+      placeholder: |
+        curl -sS -N http://127.0.0.1:7863/v1/chat/completions \
+          -H "Authorization: Bearer $API_KEY" \
+          -H "Content-Type: application/json" \
+          -d '{"model":"...","messages":[...],"stream":true}'
+    validations:
+      required: true
+
+  - type: textarea
+    id: response
+    attributes:
+      label: 最小化复现：网关响应
+      description: 完整原始响应。非流式贴 JSON 并在下方标注 `finish_reason` / `content` / `tool_calls` 是否为空；流式贴完整 SSE 帧序列（含最后是否有 `[DONE]`，不可截断）。
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 网关日志与堆栈
+      description: 覆盖故障时间窗的完整日志（请求级表格日志一行一条，请勿只贴一行）。报错若有堆栈请原样粘贴。
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: upstream_compare
+    attributes:
+      label: 对照验证
+      description: 用于区分「网关缺陷」与「上游限制」。每项都必须回答，不适用的写「不适用」。
+      value: |
+        - 同一请求在故障时刻是否命中了多个账号（是否已换号）：
+        - 是否只在特定账号 / 特定模型上失败：
+        - 该时间段 `/status` 输出（账号池、冷却、熔断状态，请脱敏 uid）：
+        - 客户端直连其它 OpenAI 兼容服务是否正常（排除客户端问题）：
+        - 问题是否为「曾经可用 → 现在不可用」的退化？若是，两次之间升级的版本与改动的配置：
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 补充信息
+      description: 是否有可用的 workaround、相关 issue 链接、发生时间（含时区）等。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/client_integration.yml
+++ b/.github/ISSUE_TEMPLATE/client_integration.yml
@@ -1,0 +1,161 @@
+name: 客户端接入问题
+description: 把 Codex / Cherry Studio / 各类 OpenAI SDK 等客户端接到网关后功能异常（读文件、调工具、流式中断、超时等）
+title: "[Client] 客户端名称 + 异常动作 + 现象，如：Codex 读取本地文件失败"
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]
+        > **「XX 客户端不能用 / 读不了文件」这类标题不会被处理。** 同一个现象至少有以下几种互不相容的成因，只有报文和日志能区分：
+        >
+        > - 客户端把请求发给了错误的 base_url / 协议，请求**根本没到网关**；
+        > - 请求到了网关但客户端依赖的字段（如 `tools`、`tool_calls`、`parallel_tool_calls`、`stream_options`）未被上游支持或被改写；
+        > - 网关返回正常，客户端自身解析 / 配置（如未启用工具、上下文长度、代理设置）有问题；
+        > - 上游对该输入形式（附件、长上下文、特定文件类型）有限制。
+        >
+        > **请按下表逐项填写。不适用的写「不适用」，无法提供的写「无法提供」并说明原因 —— 不要留空。** 缺关键项将按「无法复现」关闭。
+        >
+        > 另：接入前请先读 README [API 端点](https://github.com/Sliverkiss/workbuddy2api#api-端点) 与 [流式行为细节](https://github.com/Sliverkiss/workbuddy2api#流式行为细节)，确认客户端所需能力在当前实现中是否已声明支持。
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: 提交前自检
+      options:
+        - label: 我已用 curl 直调网关跑通同类型请求，确认网关本身可用
+          required: true
+        - label: 我已确认客户端的 base_url 指向本网关且路径为 /v1，且 api_key 与网关一致
+          required: true
+        - label: 我已脱敏（api_key、auths token、账号 uid / 手机号、上游 Cookie）
+          required: true
+
+  - type: input
+    id: client
+    attributes:
+      label: 客户端与版本
+      description: 精确到版本号，不要写「最新版」。
+      placeholder: 例：Codex CLI 0.4x.x / Cherry Studio 1.x.x / openai-python 1.x.x
+    validations:
+      required: true
+
+  - type: textarea
+    id: client_config
+    attributes:
+      label: 客户端配置
+      description: 与模型 / 网关相关的配置片段（含 base_url、model、是否开启工具调用 / 附件 / 流式）。密钥打码。截图请同时附文字。
+      render: text
+      placeholder: |
+        base_url: http://127.0.0.1:7863/v1
+        model: ...
+        tools: enabled
+        stream: true
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤
+      description: 从启动客户端到出现异常的最小步骤，包含你所操作的具体动作（如「让模型读取 ./main.go」）。
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: 期望行为 / 实际行为
+      description: 分别写明。异常提示、客户端日志请粘贴原文，不要只描述或只给截图。
+      value: |
+        - 期望：
+        - 实际：
+        - 客户端侧报错原文：
+        - 客户端是否存在「工具调用」「附件」「文件读取」相关的独立开关？当前状态：
+    validations:
+      required: true
+
+  - type: input
+    id: reached_gateway
+    attributes:
+      label: 请求是否到达网关
+      description: 对照网关日志时间戳判断。这一项决定问题在客户端还是在网关。
+      placeholder: 是（有对应日志行）/ 否（日志中无记录）/ 无法判断
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: 原始请求报文
+      description: 客户端实际发给网关的完整请求体（可通过客户端日志、抓包或网关日志获得）。必须包含 `model`、`messages`、`stream`、`tools`、`tool_choice`。缺失字段请标注「客户端未发送」。
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: response
+    attributes:
+      label: 原始响应报文
+      description: 完整原始响应。流式请贴完整 SSE 帧序列（含是否出现 `[DONE]`、是否含 `tool_calls` 增量帧），不要截断、不要只贴首尾。
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 网关日志
+      description: 覆盖该次请求的完整请求级日志行，以及任何报错与堆栈原文。
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: compare
+    attributes:
+      label: 对照验证
+      description: 用于定位是「协议不兼容」「网关缺陷」还是「上游限制」。每项必须回答，不适用的写「不适用」。
+      value: |
+        - curl 直复现：把上面同一请求用 curl 发给网关，结果如何？（贴命令与结果）
+        - 非流式（stream=false）是否正常？
+        - 不涉及文件读取 / 工具调用的普通对话是否正常？
+        - 换用另一个客户端（或 SDK）指向同一网关，是否正常？
+        - 是否仅在特定模型、特定文件类型 / 大小、特定语言文件上失败？
+        - 是否为「曾经可用 → 现在不可用」的退化？若是，期间客户端与网关各升级到什么版本：
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: 运行环境
+      description: 网关侧与客户端侧的操作系统 / 容器环境，以及两端网络关系（同机 / 局域网 / 反向代理 / 隧道）。
+      placeholder: 网关：Debian 12 + Docker 24；客户端：Windows 11；网络：同机 127.0.0.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gateway_version
+    attributes:
+      label: 网关版本来源
+      description: 便于判断是否为已知问题。
+      options:
+        - "release tag / 官方镜像"
+        - "master 分支源码自行构建"
+        - "fork 或第三方修改版（请说明）"
+        - "不确定"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 补充信息
+      description: 已有 workaround、相关 issue 链接、抓包文件链接等。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 使用疑问 / 部署求助（Discussions Q&A）
+    url: https://github.com/Sliverkiss/workbuddy2api/discussions/categories/q-a
+    about: 不确定是否为缺陷、或需要配置帮助时，请先在 Q&A 提问；答复可被标记为答案沉淀下来。
+  - name: 安全与合规边界（README 章节）
+    url: https://github.com/Sliverkiss/workbuddy2api#安全与合规
+    about: 提交任何日志、凭据或账号信息前，请先确认这一章节的使用边界与脱敏要求。
+  - name: 部署与配置文档（README）
+    url: https://github.com/Sliverkiss/workbuddy2api#快速开始
+    about: 部署、配置字段、错误分类与常见问题已在 README 中说明，请先查阅。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,99 @@
+name: 功能请求
+description: 提出新能力、行为变更或部署 / 配置体验改进
+title: "[Feature] 一句话描述希望增加或改变什么"
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!IMPORTANT]
+        > 功能请求请聚焦**问题与目标**，而不是先给实现方案。仓库维护成本有限，请说明该需求的实际使用场景与频次，便于判断优先级。
+        >
+        > 每一项都必须填写。**不适用的写「不适用」，无法提供的写「无法提供」并说明原因。**
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: 提交前自检
+      options:
+        - label: 我已搜索现有 issues 与 Discussions，确认没有相同或相近的请求
+          required: true
+        - label: 我已确认该能力目前无法通过现有配置（见 README「配置说明」）实现
+          required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 要解决的问题
+      description: 描述当前的具体痛点与场景，不要只写「希望支持 X」。
+      placeholder: |
+        我在 ___ 场景下需要 ___，但当前只能 ___，导致 ___（多花的时间 / 无法完成的事）。
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 建议方案
+      description: 你期望的行为，含配置项名、默认值、与现有语义的关系（如与账号池 / 提示词 / 冷却策略的交互）。可给 API 或配置示例。
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 已考虑的替代方案
+      description: 现有哪些绕行手段、外部工具或改动较小的方案；为什么不满足。没有则写「不适用」。
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 涉及范围
+      description: 预计受影响的子系统（可多选）。
+      multiple: true
+      options:
+        - "OpenAI 兼容接口 / 协议行为"
+        - "工具调用 / tool_calls"
+        - "系统提示词体系"
+        - "账号池 / 选号 / 会话粘性"
+        - "熔断与冷却策略"
+        - "定时任务"
+        - "状态持久化 / Redis"
+        - "可观测性（日志 / 健康检查）"
+        - "部署与配置"
+        - "文档"
+        - "其他（在下方补充）"
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: 相关环境
+      description: 与需求相关的环境上下文；无关的可写「不适用」。
+      value: |
+        - 项目版本（release tag 或 commit hash）：
+        - 部署方式：
+        - 客户端与版本：
+        - 使用场景与频次（如每日 N 次 / 仅测试环境）：
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: 贡献意愿
+      options:
+        - label: 我愿意提交 PR 实现该功能
+        - label: 我愿意协助测试并提供反馈
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 补充信息
+      description: 相关 issue 链接、上游限制说明、协议规范依据等。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -1,0 +1,50 @@
+name: 其他 / 文档与兼容性反馈
+description: 文档错误、上游行为变更、兼容性观察，或不属于上面两类的其他问题
+title: "[Other] 一句话描述"
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > [!NOTE]
+        > 本模板用于**不适合**「缺陷报告」与「功能请求」的情况，例如：README 描述与代码不一致、上游（CodeBuddy）接口行为变化、模型可用性变化。
+        > 若是使用疑问、部署求助或不确定是否为缺陷，请走 [Discussions Q&A](https://github.com/Sliverkiss/workbuddy2api/discussions/categories/q-a)。
+        >
+        > **每一项都必须填写。不适用的写「不适用」，无法提供的写「无法提供」并说明原因。**
+
+  - type: input
+    id: topic
+    attributes:
+      label: 主题
+      description: 一句话概括。避免「有问题」「不好用」等无信息量表述。
+    validations:
+      required: true
+
+  - type: textarea
+    id: detail
+    attributes:
+      label: 详细说明
+      description: 具体是什么？涉及哪个文档章节、哪段代码、哪个上游端点或哪条行为？请给出可核对的出处（文件路径 + 行号、README 章节、上游响应报文）。
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 证据
+      description: 相关日志、报文、截图、链接。文档问题请给出「文档怎么写的」与「实际是怎样的」对照。
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: 环境信息
+      description: 与主题相关的环境；不相关则写「不适用」。
+      value: |
+        - 项目版本（release tag 或 commit hash）：
+        - 部署方式：
+        - 客户端与版本：
+    validations:
+      required: true

--- a/README.md
+++ b/README.md
@@ -506,6 +506,35 @@ curl -s http://localhost:7863/v1/chat/completions \
 | Redis 粘性镜像 7 天 TTL | `internal/redisstore/redisstore.go:21` |
 | 静态模型表含 `deepseek-v4-flash` 等 | `internal/server/handler.go:146` |
 
+## 问题反馈与 Issue 规范
+
+本仓库对 issue 采用**结构化模板**（GitHub Issue Forms）。新建 issue 时必须选择模板并逐项填写，模板中的必填项由 GitHub 强制校验，缺失无法提交；空白 issue 入口已关闭。
+
+### 该走哪里
+
+| 你的情况 | 去处 |
+|---|---|
+| 不确定是否为缺陷、需要部署 / 配置帮助 | [Discussions Q&A](https://github.com/Sliverkiss/workbuddy2api/discussions/categories/q-a) |
+| 网关自身行为异常（接口报错、流式中断、换号 / 冷却异常、定时任务失败） | Issue：[缺陷报告](https://github.com/Sliverkiss/workbuddy2api/issues/new?template=bug_report.yml) |
+| 把 Codex / Cherry Studio / SDK 等客户端接入后功能异常（读文件、调工具、超时） | Issue：[客户端接入问题](https://github.com/Sliverkiss/workbuddy2api/issues/new?template=client_integration.yml) |
+| 希望新增能力或改变现有行为 | Issue：[功能请求](https://github.com/Sliverkiss/workbuddy2api/issues/new?template=feature_request.yml) |
+| 文档与代码不一致、上游行为变化 | Issue：[其他 / 文档与兼容性](https://github.com/Sliverkiss/workbuddy2api/issues/new?template=other.yml) |
+
+### 反馈质量要求
+
+1. **必须附原始报文与日志**。只有现象描述（「不能用」「报错了」「读取不了文件」）的 issue 无法定位：同一现象通常对应多种互不相容的成因，只有原始请求 / 响应 / 日志能区分。
+2. **日志与报文不得截断**。流式问题需给出完整 SSE 帧序列（含是否出现 `[DONE]`）；非流式需标注 `finish_reason` / `content` / `tool_calls` 是否为空。
+3. **先自证问题不在客户端**。按模板中的 curl 直调网关复现一遍再提交，否则无法区分「网关缺陷」与「客户端配置问题」。
+4. **标题必须包含客户端 / 场景与具体现象**，不接受「xxx 用不了」这类零信息标题。
+5. **必须脱敏**：`api_key`、`auths/` 中的 token、账号 uid / 手机号 / 邮箱、上游 Cookie 头一律打码，详见[安全与合规](#安全与合规)。
+6. 不适用的项写「不适用」，确实无法提供的写「无法提供」并说明原因，**不要留空**。
+
+### 处理规则
+
+- 信息不完整的 issue 会被打上 `needs-info` 标签并要求补充；**7 天内无回应将按「无法复现」关闭**，补充后可随时重新打开。
+- 已确认的缺陷会打 `bug` 标签并排期；功能请求会打 `enhancement` 并在讨论确定方案后再动手，请勿直接提未经讨论的大改动 PR。
+- 涉及上游（CodeBuddy）侧限制、模型可用性变化的问题，若确认为上游行为，会标注结论后关闭。
+
 ## 免责声明
 
 本项目仅供学习和研究使用。使用者需遵守 CodeBuddy 服务条款，自行承担使用风险（包括账号封禁、条款违约等）。作者不对任何因使用本项目产生的直接或间接损失负责。


### PR DESCRIPTION
## 背景

issue #47（「接入到 codex 上，读取不了文件」）正文为空、无环境信息、无报文、无日志，无法定位。这类反馈无法处理的原因是：**同一个现象至少对应四种互不相容的成因**，仅凭标题无法区分。

1. 客户端请求根本没到网关（base_url / 路径 / 鉴权配置错误）；
2. 请求到了网关，但客户端依赖的字段（`tools`、`tool_calls`、`stream_options` 等）未被上游支持或被改写；
3. 网关返回正常，客户端自身解析或配置（工具开关、上下文长度、代理）有问题；
4. 上游对特定输入形式（附件、长上下文、特定文件类型）有限制。

因此本 PR 把「信息采集」前置到**提交阶段**，由 GitHub 强制校验，而不是事后追问。

## 改动内容

纯文档与仓库配置，**不触碰任何 Go 代码，无运行时行为变化**。

### 新增 `.github/ISSUE_TEMPLATE/`

| 文件 | 名称 | 触发场景 | 项数 / 必填 |
|---|---|---|---|
| `bug_report.yml` | 缺陷报告 | 网关自身行为异常 | 15 / 12 |
| `client_integration.yml` | 客户端接入问题 | Codex / Cherry Studio / SDK 接入后异常 | 14 / 11 |
| `feature_request.yml` | 功能请求 | 新能力、行为变更 | 9 / 5 |
| `other.yml` | 其他 / 文档与兼容性 | 文档不一致、上游行为变化 | 5 / 4 |
| `config.yml` | 模板选择器 | 关闭空白 issue，引导 Q&A 与 README | — |

### 关键设计决策

**1. 用 Issue Forms（`.yml`）而非 Markdown 模板**
Markdown 模板的提示只是建议，用户可整段删除；Issue Forms 的 `validations.required: true` 由 GitHub 在提交时强制拦截。结构化字段（dropdown / checkboxes）同时产出可筛选的数据，后续可用 `gh issue list --label` 过滤。

**2. `client_integration.yml` 专门针对 #47 这类反馈**
- 顶部先用 `markdown` 块列出上述四种成因，逼提交者自行分类；
- 标题规则固定为 `[Client] 客户端名称 + 异常动作 + 现象`，并明确写「XX 客户端读不了文件」这类标题不会被处理；
- 必填「**请求是否到达网关**」—— 这一项直接把问题在客户端侧与网关侧之间二分；
- 必填完整请求体（含 `tools` / `tool_choice` / `stream`，缺失字段须标注「客户端未发送」）与完整响应（流式须给全套 SSE 帧，禁止只贴首尾、禁止只给截图）；
- 必填「对照验证」：curl 直复现、`stream=false` 对比、非文件/非工具场景对比、换客户端对比、是否退化及退化前后版本。

**3. 字段对齐项目真实语义**（而非通用模板）
- 影响范围下拉项直接映射现有子系统：账号池 / 选号 / 会话粘性、熔断与冷却（402 / 404 / 429）、定时任务（签到 / 活跃 / 旅行 / 保活）、状态持久化（`state.json` / Upstash）、系统提示词体系（`custom` / `passthrough`）；
- 环境字段对齐 README 的部署方式（Docker Compose / 源码构建），并要求版本写 release tag 或 commit hash，不接受「最新版」；
- 脱敏要求对齐 README[「安全与合规」](https://github.com/Sliverkiss/workbuddy2api#安全与合规)：`api_key`、`auths/` token、账号 uid / 手机号 / 邮箱、上游 Cookie 头一律打码。

**4. 统一话术堵住敷衍**
所有模板均写明：不适用的写「不适用」，无法提供的写「无法提供」并说明原因，**不要留空**；关键项缺失按「无法复现」处理。

### README 变化

在「关键断言 ↔ 代码出处」与「免责声明」之间新增 **「问题反馈与 Issue 规范」** 章节：分流表（Discussions Q&A vs 三类 issue）、反馈质量要求 6 条、处理规则（`needs-info` → 7 天无回应关闭、补充后可重开）。

## 验证

对 5 个 YAML 逐项做了 schema 校验，全部通过：

- 顶层键白名单（`name` / `description` / `title` / `labels` / `body`）；
- 各 `type` 的 `attributes` 白名单、`render` 仅用于 `textarea` / `input`；
- `validations.required` 不用于 `markdown`，且 `required` 仅用于 `textarea` / `input` / `dropdown` / `checkboxes`；
- `value` 与 `placeholder` 不同时出现（GitHub 会报错）；
- `dropdown` / `checkboxes` 选项结构校验，`default` 必须属于 `options`；
- 所有 `id` 唯一且仅含字母数字下划线；`name` ≤ 64 字符、`description` ≤ 200 字符。

合并后建议在 GitHub 上实际打开一次新建 issue 页面，确认四个模板均正常渲染、必填项生效。

## 合并前需要确认的一项

README 与 `bug_report.yml` 的处理规则引用了 `needs-info` 标签，**该标签当前仓库不存在**（现有标签只有 GitHub 默认集）。需在合并前或合并后创建：

```bash
gh label create needs-info --repo Sliverkiss/workbuddy2api \
  --color FBCA04 --description "信息不足，等待提交者补充"
```

若不想引入新标签，我可以把文档中的 `needs-info` 改为现有标签（如 `question`）。
