### PR TITLE
fix(docker): 删除对已移除脚本 probe_active.py 的 COPY（当前 master docker build 必挂）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ COPY --from=build /out/signin_bin /app/signin_bin
 COPY --from=build /out/login /app/login
 COPY --from=build /out/credit /app/credit
 COPY login.sh signin.sh credit.sh /app/
-COPY scripts/probe_active.py /app/scripts/probe_active.py
 RUN sed -i 's/\r$//' /app/login.sh /app/signin.sh /app/credit.sh && chmod 755 /app/login.sh /app/signin.sh /app/credit.sh
 # 镜像不带真实配置：落 example 作为默认（生产由挂载卷 /app/config.json 覆盖）
 COPY config.example.json /app/config.json


### PR DESCRIPTION
## 问题

`4a80249`（refactor(scripts): 清理单任务脚本，脚本库收敛为 task_runner + task_common）删除了 `scripts/probe_active.py`，但 Dockerfile 第 27 行的 COPY 未同步移除：

```dockerfile
COPY scripts/probe_active.py /app/scripts/probe_active.py
```

COPY 不存在的文件是 docker build 的硬错误——当前 master（4a80249）上任何 Docker 构建（含 README 推荐的 `docker compose up -d --build`）都会在构建阶段直接失败。

## 复现

```bash
git clone https://github.com/Sliverkiss/workbuddy2api.git
cd workbuddy2api
docker build .
# => COPY scripts/probe_active.py: failed to compute cache key: ... not found
```

## 修复

最小改动：删掉该行（1 deletion）。全文件仅此一处引用 `scripts/`，无其他依赖；`.dockerignore` 与 compose 均不涉及。

## 顺带发现（不在本 PR 范围，供参考）

README 仍有 3 处引用 `scripts/probe_active.py`（L302/L404/L418，含"手动诊断/补跑"使用指引），且对新的 `task_runner.py` 零引用——同一提交的文档欠账，可在后续提交里一并处理。