### PR TITLE
fix(server): /healthz 计入 6004 模型级豁免账号（探活与 chat 可达性口径对齐）

### DIFF
--- a/internal/pool/entry.go
+++ b/internal/pool/entry.go
@@ -118,15 +118,24 @@ func (e *entry) healthy(now time.Time) bool {
 	return true
 }
 
+// modelExempt 报告账号是否处于「6004 模型级软冷却」形态：冷却由带解析时间的
+// 6004 触发（coolKind==CoolSoft 且 softRateModel 非空），且尚未禁用、未熔断。
+// 此形态下账号仅对 softRateModel 不可用，对其他模型仍可选（issue #31）。
+// healthyForModel 与 ServableNow 共用本谓词，保证 chat 选号与探活口径一致。
+// 调用方负责 now 与冷却有效性的判断（本方法只看形态，不看 until 是否已过）。
+func (e *entry) modelExempt() bool {
+	return e.coolKind == CoolSoft && e.softRateModel != "" &&
+		!e.disabled && e.breakerUntil.IsZero()
+}
+
 // healthyForModel 报告账号对指定 model 是否可选（含模型级豁免）：
 // 冷却为由 6004 触发的**模型级**软冷却（softRateModel 非空）且请求模型不同
 // （softRateModel != reqModel）时，跳过冷却判定——该模型限流不代表账号在其他
 // 模型下不可用（issue #31）。空 reqModel / 未记录模型 / 同模型 → 与 healthy 一致。
 func (e *entry) healthyForModel(now time.Time, reqModel string) bool {
-	if !e.healthy(now) && reqModel != "" && e.softRateModel != "" &&
-		e.coolKind == CoolSoft && e.softRateModel != reqModel {
-		// 非 healthy 但属于可豁免场景：仍受 disabled/breakerUntil 约束。
-		return !e.disabled && e.breakerUntil.IsZero()
+	if !e.healthy(now) && reqModel != "" && e.modelExempt() && e.softRateModel != reqModel {
+		// 非 healthy 但属于可豁免场景：仍受 disabled/breakerUntil 约束（modelExempt 已含）。
+		return true
 	}
 	return e.healthy(now)
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -942,6 +942,61 @@ func TestPickExcludingForModelBreakerStillBlocks(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// ServableNow 的模型级豁免（issue #31 探活侧）：6004 单模型限流时，账号对该模型
+// 不可用但对其他模型仍可选，/healthz 不得因"全号被某一模型限流"而误报 503。
+// ---------------------------------------------------------------------------
+
+func TestServableNowModelExemptCounts(t *testing.T) {
+	// 单号处于 6004 模型级软冷却（带解析时间、记录 softRateModel）→ 其他模型仍可达，
+	// ServableNow 必须为 true（与 chat 的 healthyForModel 放行切模型请求同口径）。
+	// 反向（同模型不可选）已由 TestPickExcludingForModelSkipsSoftCoolingSameModel 覆盖；
+	// 本池无其他候选，同模型选号会走全冷却兜底，不在此重复断言。
+	p := New("")
+	p.Add(&auth.Auth{UID: "u1"})
+	p.CooldownSoftForModel("u1", time.Minute, time.Now().Add(5*time.Minute), "glm-5.3", "429 rate limit")
+	if !p.ServableNow() {
+		t.Fatal("model-exempt account must keep pool servable (other models reachable)")
+	}
+}
+
+func TestServableNowPlainSoftNotExempt(t *testing.T) {
+	// 普通软冷却（无 softRateModel，非 6004 模型级）→ 账号级不可用，ServableNow 必须 false。
+	// 守门：豁免不得从模型级泄漏到普通冷却。
+	p := New("")
+	p.Add(&auth.Auth{UID: "u1"})
+	p.Cooldown("u1", CoolSoft, time.Minute, "429 rate limit")
+	if p.ServableNow() {
+		t.Fatal("plain soft cooling (no model) must NOT be servable")
+	}
+}
+
+func TestServableNowExemptButInFlightFull(t *testing.T) {
+	// 模型豁免形态 + 在途占满 → 仍不可服务（在途维度独立于豁免，探活须叠加判定）。
+	p := New("")
+	p.Add(&auth.Auth{UID: "u1"})
+	p.SetMaxInFlight(1)
+	p.CooldownSoftForModel("u1", time.Minute, time.Now().Add(5*time.Minute), "glm-5.3", "429 rate limit")
+	if !p.Acquire("u1") {
+		t.Fatal("acquire should succeed at max=1")
+	}
+	defer p.Release("u1")
+	if p.ServableNow() {
+		t.Fatal("model-exempt but in-flight-full account must not count as servable")
+	}
+}
+
+func TestServableNowExemptButDisabled(t *testing.T) {
+	// 模型豁免形态 + 被禁用（session dead）→ disabled 优先级最高，ServableNow 必须 false。
+	p := New("")
+	p.Add(&auth.Auth{UID: "u1"})
+	p.CooldownSoftForModel("u1", time.Minute, time.Now().Add(5*time.Minute), "glm-5.3", "429 rate limit")
+	p.Disable("u1", "session dead")
+	if p.ServableNow() {
+		t.Fatal("disabled account must never be servable, even in model-exempt form")
+	}
+}
+
 // TestSoftRateModelClearedByPlainCooldown 回归：6004 模型冷却后，若账号又经历一次
 // **非模型级**软冷却（plain Cooldown），softRateModel 必须被清空——否则上次 6004 的
 // 模型豁免会泄漏到本次账号级限流上，导致"换模型请求"错误绕过本次冷却。

--- a/internal/pool/state.go
+++ b/internal/pool/state.go
@@ -292,16 +292,24 @@ func (p *Pool) CountsDetailed() (total, healthy, cooling, disabled, inFlightFull
 	return total, healthy, cooling, disabled, inFlightFull
 }
 
-// ServableNow 报告池当前是否可服务：存在至少一个 healthy 且未占满在途名额的账号。
+// ServableNow 报告池当前是否可服务：存在至少一个（对任意模型）healthy 且未占满在途名额的账号。
 // 与 CountsDetailed 的 healthy 口径不同：healthy 只看 disabled/until/breakerUntil（状态机权威判定），
 // 不看 inFlight；ServableNow 额外叠加在途维度，与 chat 的真实可达性（Pick 会跳过 inFlightFull 账号）对齐。
 // 专供 /healthz 用，避免"全账号 healthy 但都占满"时探活误报 200 而 chat 返回 503 的口径裂缝。
+//
+// 模型级豁免（issue #31 的探活侧补齐）：6004 模型级软冷却中的账号（modelExempt 形态）
+// 对触发模型不可用、对其他模型仍可选——chat 的 healthyForModel 已按此放行切模型请求，
+// 探活必须同口径，否则"全号被 v4.1 限流但 glm 可用"时 chat 实际 200 而 /healthz 误报 503。
+// /healthz 无请求模型上下文，取"存在可服务模型"的存在性语义（与 chat 可达性等价）。
 func (p *Pool) ServableNow() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	now := time.Now()
 	for _, e := range p.byUID {
-		if e.healthy(now) && !p.inFlightFull(e) {
+		if p.inFlightFull(e) {
+			continue
+		}
+		if e.healthy(now) || e.modelExempt() {
 			return true
 		}
 	}

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -1194,6 +1194,21 @@ func TestHealthz503WhenAllInFlightFull(t *testing.T) {
 	}
 }
 
+// TestHealthz200WhenAllModelExempt 全部账号处于 6004 单模型软冷却（对其他模型仍可选）
+// → /healthz 必须 200，与 chat 的模型级豁免（切模型立即可用）同口径。
+// 回归：此前 ServableNow 只看账号级 healthy，"全号被 v4.1 限流但 glm 可用"时误报 503。
+func TestHealthz200WhenAllModelExempt(t *testing.T) {
+	p := testPoolWith(&auth.Auth{UID: "u1", AccessToken: "at", ExpiresAt: 9999999999})
+	p.CooldownSoftForModel("u1", time.Minute, time.Now().Add(5*time.Minute), "glm-5.3", "429 rate limit")
+	// 账号级 healthy 已为 0（冷却中），但模型豁免使 chat 对非 glm 请求仍可达。
+	h := NewHandler(Config{Pool: p, Upstream: upstream.New()})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/healthz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d want 200 (model-exempt account keeps pool servable)", rec.Code)
+	}
+}
+
 // TestHealthz200WhenHealthy 有健康账号 → 200。
 func TestHealthz200WithHealthy(t *testing.T) {
 	p := testPoolWith(&auth.Auth{UID: "u1", AccessToken: "at", ExpiresAt: 9999999999})


### PR DESCRIPTION
## 问题

PR #51（issue #31 的模型级豁免）把 chat 选号改成了模型感知：`pick` 在请求带 model 时用 `healthyForModel`，6004 单模型软冷却中的账号**对其他模型仍可选**。但 `/healthz` 依赖的 `ServableNow()` 仍用账号级 `healthy` 判定，没有同步。

后果：**全部账号被同一模型（如 v4.1-flash）6004 限流、但其他模型（如 glm）完全可用时，chat 实际 200 而 /healthz 误报 503**。这违背了 `ServableNow` 自身注释声明的契约——「与 chat 的真实可达性对齐」；而 healthz 注释也写明它的设计目的就是防止探活与 chat 出现口径裂缝。LB/编排（README 推荐 `/healthz` 接负载均衡）会据此误摘健康实例。

实测复现（4 号池、全号处于 v4.1 的 6004 冷却）：

```
GET /v1/chat/completions {model: glm-5.3-flash}  → 200 ✅
GET /healthz                                     → 503 ❌
```

## 修复

1. **`entry.go`**：抽出共享谓词 `modelExempt()`（`CoolSoft` + `softRateModel` 非空 + 未禁用 + 未熔断），`healthyForModel` 重构复用——豁免条件单点定义，两处判定不会再漂移
2. **`state.go`**：`ServableNow` 的判定从 `healthy` 改为 `healthy || modelExempt`（在途维度仍独立叠加）。/healthz 无请求模型上下文，取「存在可服务模型」的存在性语义，与 chat 可达性等价

## 测试（5 例）

- `TestServableNowModelExemptCounts`：6004 模型豁免账号保持池可服务（核心回归）
- `TestServableNowPlainSoftNotExempt`：守门——普通软冷却（无 softRateModel）不得豁免
- `TestServableNowExemptButInFlightFull`：豁免 + 在途占满仍不可服务（在途维度独立）
- `TestServableNowExemptButDisabled`：豁免 + 禁用仍不可服务（disabled 优先级最高）
- `TestHealthz200WhenAllModelExempt`：端到端，全号模型豁免时 /healthz 返回 200

`go build ./... && go vet` 干净；`go test ./internal/pool/ ./internal/server/` 除 `TestPickAntiThunderingHerd`、`TestSoftRateModelNotPersistedToState` 两个失败外全绿——**这两个在未改动的 origin/master 上同样失败**（Windows 时钟粒度环境问题，与本 PR 无关，已用 `git stash` 基线对照确认）。

## 设计说明

- `softRateModel` 不持久化是 `entry.go` 注释里的有意设计（「运行态语义：重启清零，退化为现状」），本 PR 不涉及重启后的豁免保持
- `/status` 的 `healthy` 计数保持账号级口径不变（状态机权威判定），只有探活语义扩展——避免影响运维对「冷却数」的既有理解