### PR TITLE
fix(pool): persist_unix.go 缺 //go:build unix 导致 Windows 构建失败

### DIFF
--- a/internal/pool/persist_other.go
+++ b/internal/pool/persist_other.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+// persist_other.go 非 Unix 平台（Windows 等）回落：无 POSIX uid/gid 语义，
+// 恒返回 0（仅影响首错日志的属主信息可读性）。
+// syscall.Stat_t 在 Windows 不存在，本文件与 persist_unix.go 由构建标签互斥。
+package pool
+
+import (
+	"os"
+)
+
+// statUID 非 Unix 平台恒 0。
+func statUID(info os.FileInfo) int { return 0 }
+
+// statGID 非 Unix 平台恒 0。
+func statGID(info os.FileInfo) int { return 0 }

--- a/internal/pool/persist_unix.go
+++ b/internal/pool/persist_unix.go
@@ -1,5 +1,8 @@
+//go:build unix
+
 // persist_unix.go 平台相关：从 os.FileInfo 取属主 uid/gid（Unix）。
-// 非 Unix 平台或 Sys() 返回 nil（测试 fake）时回落 0，仅影响日志可读性。
+// Sys() 返回 nil（测试 fake）时回落 0，仅影响日志可读性。
+// 非 Unix（如 Windows）由 persist_other.go 提供恒 0 回落实现。
 package pool
 
 import (


### PR DESCRIPTION
## 问题

`95668c0`（state.json 首错详报）新增 `internal/pool/persist_unix.go`，意图是「非 Unix 平台回落 0」（文件注释原话），但**没有加构建标签**。当前 master（4d4c6ef）上：

```bash
$ go build ./...
internal/pool/persist_unix.go:12:35: undefined: syscall.Stat_t
internal/pool/persist_unix.go:20:35: undefined: syscall.Stat_t
```

`syscall.Stat_t` 在 Windows 不存在（Go 标准库 syscall 包的 Windows 实现无此类型），整个项目在 `GOOS=windows` 下无法编译——README 支持的 Windows 原生部署路径（go build 直接跑）被阻断。

## 复现

Windows / 任意交叉编译：

```bash
GOOS=windows go build ./...   # undefined: syscall.Stat_t
```

## 修复

标准 Go 平台文件互斥模式：

1. `persist_unix.go` 头部加 `//go:build unix`（go.mod 为 1.22.5，支持 unix 标签）
2. 新增 `persist_other.go`（`//go:build !unix`）：`statUID`/`statGID` 恒返回 0，兑现注释里「非 Unix 回落 0、仅影响日志可读性」的原意

## 验证

- `GOOS=windows go build ./...` ✅
- `GOOS=linux go build ./...` ✅（unix 路径不变，Linux/Docker 行为零变化）
- `go test ./internal/pool/`（Windows 本机）✅

改动仅 2 文件 +20/-1，无逻辑变化。